### PR TITLE
Add Requirement filter

### DIFF
--- a/walk-in-interview/src/main/java/com/google/job/data/Job.java
+++ b/walk-in-interview/src/main/java/com/google/job/data/Job.java
@@ -70,7 +70,7 @@ public final class Job {
     public static final class JobBuilder {
         // Optional parameters - initialized to default values
         private String jobId = "";
-        private Map<String, Boolean> requirements = ImmutableMap.of(); // Maps with non-string keys are not supported
+        private Map<String, Boolean> requirements = ImmutableMap.of();
         private JobDuration jobDuration = JobDuration.OTHER;
 
         // TODO(issue/25): merge the account stuff into job post.
@@ -203,7 +203,7 @@ public final class Job {
         return jobPay;
     }
 
-    /** Returns a list of requirements (stable ids) of the job post. */
+    /** Returns a map of requirements (stable ids) of the job post. */
     public Map<String, Boolean> getRequirements() {
         return requirements;
     }

--- a/walk-in-interview/src/main/java/com/google/job/data/Job.java
+++ b/walk-in-interview/src/main/java/com/google/job/data/Job.java
@@ -14,7 +14,7 @@ public final class Job {
     private final Location jobLocation;
     private final String jobDescription;
     private final JobPayment jobPay;
-    private final Map<Requirement, Boolean> requirements; // requirement enum value : true/false
+    private final Map<String, Boolean> requirements; // requirement stable id : true/false
     private final long postExpiryTimestamp;
     private final JobDuration jobDuration;
 
@@ -70,7 +70,7 @@ public final class Job {
     public static final class JobBuilder {
         // Optional parameters - initialized to default values
         private String jobId = "";
-        private Map<Requirement, Boolean> requirements = ImmutableMap.of();
+        private Map<String, Boolean> requirements = ImmutableMap.of(); // Maps with non-string keys are not supported
         private JobDuration jobDuration = JobDuration.OTHER;
 
         // TODO(issue/25): merge the account stuff into job post.
@@ -129,16 +129,16 @@ public final class Job {
             return this;
         }
 
-        public JobBuilder setRequirements(List<Requirement> requirements) {
+        public JobBuilder setRequirements(List<String> requirements) {
             // Changes requirements into set to make "contains" operation O(1)
-            Set<Requirement> requirementsSet = new HashSet<>(requirements);
+            Set<String> requirementsSet = new HashSet<>(requirements);
 
-            // Gets all requirements
-            List<Requirement> requirementsList = Arrays.asList(Requirement.values());
+            // Gets all requirements stable id
+            List<String> requirementsList = Requirement.getAllRequirementIds();
 
-            ImmutableMap.Builder<Requirement, Boolean> requirementsMap = ImmutableMap.builder();
+            ImmutableMap.Builder<String, Boolean> requirementsMap = ImmutableMap.builder();
 
-            for (Requirement requirement: requirementsList) {
+            for (String requirement: requirementsList) {
                 requirementsMap.put(requirement, requirementsSet.contains(requirement));
             }
 
@@ -216,8 +216,8 @@ public final class Job {
         return jobPay;
     }
 
-    /** Returns a list of requirements of the job post. */
-    public Map<Requirement, Boolean> getRequirements() {
+    /** Returns a list of requirements (stable ids) of the job post. */
+    public Map<String, Boolean> getRequirements() {
         return requirements;
     }
 

--- a/walk-in-interview/src/main/java/com/google/job/data/Job.java
+++ b/walk-in-interview/src/main/java/com/google/job/data/Job.java
@@ -129,21 +129,8 @@ public final class Job {
             return this;
         }
 
-        public JobBuilder setRequirements(List<String> requirements) {
-            // Changes requirements into set to make "contains" operation O(1)
-            Set<String> requirementsSet = new HashSet<>(requirements);
-
-            // Gets all requirements stable id
-            List<String> requirementsList = Requirement.getAllRequirementIds();
-
-            ImmutableMap.Builder<String, Boolean> requirementsMap = ImmutableMap.builder();
-
-            for (String requirement: requirementsList) {
-                requirementsMap.put(requirement, requirementsSet.contains(requirement));
-            }
-
-            this.requirements = requirementsMap.build();
-
+        public JobBuilder setRequirements(Map<String, Boolean> requirements) {
+            this.requirements = ImmutableMap.copyOf(requirements);
             return this;
         }
 

--- a/walk-in-interview/src/main/java/com/google/job/data/Job.java
+++ b/walk-in-interview/src/main/java/com/google/job/data/Job.java
@@ -130,53 +130,23 @@ public final class Job {
         }
 
         public JobBuilder setRequirements(Map<String, Boolean> requirements) {
-            List<String> requirementsList = Requirement.getAllRequirementIds();
+            Map<String, Boolean> inputRequirementsMap = new HashMap<>(requirements);
+            Set<String> requirementsSet = new HashSet<>(Requirement.getAllRequirementIds());
 
-            if (requirements.size() == requirementsList.size()) {
-                this.requirements = ImmutableMap.copyOf(requirements);
-                return this;
-            } else if (requirements.size() < requirements.size()) {
-                // some requirements are not contained when sent from client
+            // Removes redundant requirement
+            inputRequirementsMap.entrySet().removeIf(entry -> !requirementsSet.contains(entry.getKey()));
 
-                Map<String, Boolean> requirementsMap = new HashMap<>(requirements);
-
-                for (String requirement: requirementsList) {
-                    if (requirementsMap.containsKey(requirement)) {
-                        continue;
-                    }
-
-                    requirementsMap.put(requirement, false);
+            // Checks if requirement missing and adds accordingly
+            for (String requirement: requirementsSet) {
+                if (inputRequirementsMap.containsKey(requirement)) {
+                    continue;
                 }
 
-                this.requirements = ImmutableMap.copyOf(requirementsMap);
-                return this;
-            } else {
-                // excessive requirements are sent from the client
-
-                Map<String, Boolean> requirementsMap = new HashMap<>(requirements);
-                Set<String> requirementsSet = new HashSet<>(requirementsList);
-
-                // Removes redundant requirement
-                for (String requirement: requirementsMap.keySet()) {
-                    if (requirementsSet.contains(requirement)) {
-                        continue;
-                    }
-
-                    requirementsMap.remove(requirement);
-                }
-
-                // Checks if requirement missing and adds accordingly
-                for (String requirement: requirementsSet) {
-                    if (requirementsMap.containsKey(requirement)) {
-                        continue;
-                    }
-
-                    requirementsMap.put(requirement, false);
-                }
-
-                this.requirements = ImmutableMap.copyOf(requirementsMap);
-                return this;
+                inputRequirementsMap.put(requirement, false);
             }
+
+            this.requirements = ImmutableMap.copyOf(inputRequirementsMap);
+            return this;
         }
 
         public JobBuilder setPostExpiry(long postExpiryTimestamp) {

--- a/walk-in-interview/src/main/java/com/google/job/data/Job.java
+++ b/walk-in-interview/src/main/java/com/google/job/data/Job.java
@@ -130,8 +130,53 @@ public final class Job {
         }
 
         public JobBuilder setRequirements(Map<String, Boolean> requirements) {
-            this.requirements = ImmutableMap.copyOf(requirements);
-            return this;
+            List<String> requirementsList = Requirement.getAllRequirementIds();
+
+            if (requirements.size() == requirementsList.size()) {
+                this.requirements = ImmutableMap.copyOf(requirements);
+                return this;
+            } else if (requirements.size() < requirements.size()) {
+                // some requirements are not contained when sent from client
+
+                Map<String, Boolean> requirementsMap = new HashMap<>(requirements);
+
+                for (String requirement: requirementsList) {
+                    if (requirementsMap.containsKey(requirement)) {
+                        continue;
+                    }
+
+                    requirementsMap.put(requirement, false);
+                }
+
+                this.requirements = ImmutableMap.copyOf(requirementsMap);
+                return this;
+            } else {
+                // excessive requirements are sent from the client
+
+                Map<String, Boolean> requirementsMap = new HashMap<>(requirements);
+                Set<String> requirementsSet = new HashSet<>(requirementsList);
+
+                // Removes redundant requirement
+                for (String requirement: requirementsMap.keySet()) {
+                    if (requirementsSet.contains(requirement)) {
+                        continue;
+                    }
+
+                    requirementsMap.remove(requirement);
+                }
+
+                // Checks if requirement missing and adds accordingly
+                for (String requirement: requirementsSet) {
+                    if (requirementsMap.containsKey(requirement)) {
+                        continue;
+                    }
+
+                    requirementsMap.put(requirement, false);
+                }
+
+                this.requirements = ImmutableMap.copyOf(requirementsMap);
+                return this;
+            }
         }
 
         public JobBuilder setPostExpiry(long postExpiryTimestamp) {

--- a/walk-in-interview/src/main/java/com/google/job/data/Job.java
+++ b/walk-in-interview/src/main/java/com/google/job/data/Job.java
@@ -3,10 +3,7 @@ package com.google.job.data;
 import com.google.common.collect.ImmutableMap;
 
 import javax.annotation.Nullable;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 /** Class for a job post. */
 public final class Job {
@@ -17,7 +14,7 @@ public final class Job {
     private final Location jobLocation;
     private final String jobDescription;
     private final JobPayment jobPay;
-    private final Map<String, Boolean> requirements;
+    private final Map<Requirement, Boolean> requirements; // requirement enum value : true/false
     private final long postExpiryTimestamp;
     private final JobDuration jobDuration;
 
@@ -73,7 +70,7 @@ public final class Job {
     public static final class JobBuilder {
         // Optional parameters - initialized to default values
         private String jobId = "";
-        private Map<String, Boolean> requirements = ImmutableMap.of();
+        private Map<Requirement, Boolean> requirements = ImmutableMap.of();
         private JobDuration jobDuration = JobDuration.OTHER;
 
         // TODO(issue/25): merge the account stuff into job post.
@@ -132,16 +129,20 @@ public final class Job {
             return this;
         }
 
-        public JobBuilder setRequirements(List<String> requirements) {
+        public JobBuilder setRequirements(List<Requirement> requirements) {
             // Changes requirements into set to make "contains" operation O(1)
-            Set<String> requirementsSet = new HashSet<>(requirements);
+            Set<Requirement> requirementsSet = new HashSet<>(requirements);
 
-            // Gets all requirements with localized name
-            List<String> requirementsList = Requirement.getAllLocalizedNames("en");
+            // Gets all requirements
+            List<Requirement> requirementsList = Arrays.asList(Requirement.values());
 
-            for (String requirement: requirementsList) {
-                this.requirements.put(requirement, requirementsSet.contains(requirement));
+            ImmutableMap.Builder<Requirement, Boolean> requirementsMap = ImmutableMap.builder();
+
+            for (Requirement requirement: requirementsList) {
+                requirementsMap.put(requirement, requirementsSet.contains(requirement));
             }
+
+            this.requirements = requirementsMap.build();
 
             return this;
         }
@@ -216,7 +217,7 @@ public final class Job {
     }
 
     /** Returns a list of requirements of the job post. */
-    public Map<String, Boolean> getRequirements() {
+    public Map<Requirement, Boolean> getRequirements() {
         return requirements;
     }
 

--- a/walk-in-interview/src/main/java/com/google/job/data/Job.java
+++ b/walk-in-interview/src/main/java/com/google/job/data/Job.java
@@ -1,9 +1,12 @@
 package com.google.job.data;
 
-import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
 import javax.annotation.Nullable;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /** Class for a job post. */
 public final class Job {
@@ -14,7 +17,7 @@ public final class Job {
     private final Location jobLocation;
     private final String jobDescription;
     private final JobPayment jobPay;
-    private final List<String> requirements;
+    private final Map<String, Boolean> requirements;
     private final long postExpiryTimestamp;
     private final JobDuration jobDuration;
 
@@ -40,7 +43,7 @@ public final class Job {
         this.jobLocation = new Location();
         this.jobDescription = "";
         this.jobPay = new JobPayment();
-        this.requirements = ImmutableList.of();
+        this.requirements = ImmutableMap.of();
         this.postExpiryTimestamp = 0;
         this.jobDuration = JobDuration.OTHER;
     }
@@ -70,7 +73,7 @@ public final class Job {
     public static final class JobBuilder {
         // Optional parameters - initialized to default values
         private String jobId = "";
-        private List<String> requirements = ImmutableList.of();
+        private Map<String, Boolean> requirements = ImmutableMap.of();
         private JobDuration jobDuration = JobDuration.OTHER;
 
         // TODO(issue/25): merge the account stuff into job post.
@@ -130,7 +133,16 @@ public final class Job {
         }
 
         public JobBuilder setRequirements(List<String> requirements) {
-            this.requirements = ImmutableList.copyOf(requirements);
+            // Changes requirements into set to make "contains" operation O(1)
+            Set<String> requirementsSet = new HashSet<>(requirements);
+
+            // Gets all requirements with localized name
+            List<String> requirementsList = Requirement.getAllLocalizedNames("en");
+
+            for (String requirement: requirementsList) {
+                this.requirements.put(requirement, requirementsSet.contains(requirement));
+            }
+
             return this;
         }
 
@@ -204,7 +216,7 @@ public final class Job {
     }
 
     /** Returns a list of requirements of the job post. */
-    public List<String> getRequirements() {
+    public Map<String, Boolean> getRequirements() {
         return requirements;
     }
 

--- a/walk-in-interview/src/main/java/com/google/job/data/JobsDatabase.java
+++ b/walk-in-interview/src/main/java/com/google/job/data/JobsDatabase.java
@@ -136,12 +136,12 @@ public final class JobsDatabase {
     }
 
     /** Returns future of all ACTIVE and eligible job posts in database. */
-    public Future<Collection<Job>> fetchAllEligibleJobs(List<Requirement> skills) throws IOException {
-        // Gets all requirements
-        List<Requirement> requirementsList = Arrays.asList(Requirement.values());
+    public Future<Collection<Job>> fetchAllEligibleJobs(List<String> skills) throws IOException {
+        // Gets all requirements stable id
+        List<String> requirementsList = Requirement.getAllRequirementIds();
 
         // Gets a list of requirements which the applicant does not have
-        List<Requirement> negateSkills = new ArrayList<>(requirementsList);
+        List<String> negateSkills = new ArrayList<>(requirementsList);
         negateSkills.removeAll(skills);
 
         final Query activeJobsQuery = FireStoreUtils.getFireStore()
@@ -151,7 +151,7 @@ public final class JobsDatabase {
         // Eligible post: post whose requirements do not contain (field is false)
         // the skills that applicant does not have
         Query eligiblePostQuery = activeJobsQuery;
-        for (Requirement negateSkill: negateSkills) {
+        for (String negateSkill: negateSkills) {
             String fieldPath = String.format("%s.%s", JOB_REQUIREMENTS_FIELD, negateSkill);
             eligiblePostQuery = eligiblePostQuery.whereEqualTo(fieldPath, false);
         }

--- a/walk-in-interview/src/main/java/com/google/job/data/JobsDatabase.java
+++ b/walk-in-interview/src/main/java/com/google/job/data/JobsDatabase.java
@@ -141,8 +141,8 @@ public final class JobsDatabase {
         List<String> requirementsList = Requirement.getAllRequirementIds();
 
         // Gets a list of requirements which the applicant does not have
-        List<String> negateSkills = new ArrayList<>(requirementsList);
-        negateSkills.removeAll(skills);
+        List<String> excludedSkills = new ArrayList<>(requirementsList);
+        excludedSkills.removeAll(skills);
 
         final Query activeJobsQuery = FireStoreUtils.getFireStore()
                 .collection(JOB_COLLECTION)
@@ -151,7 +151,7 @@ public final class JobsDatabase {
         // Eligible post: post whose requirements do not contain (field is false)
         // the skills that applicant does not have
         Query eligiblePostQuery = activeJobsQuery;
-        for (String negateSkill: negateSkills) {
+        for (String negateSkill: excludedSkills) {
             String fieldPath = String.format("%s.%s", JOB_REQUIREMENTS_FIELD, negateSkill);
             eligiblePostQuery = eligiblePostQuery.whereEqualTo(fieldPath, false);
         }

--- a/walk-in-interview/src/main/java/com/google/job/data/JobsDatabase.java
+++ b/walk-in-interview/src/main/java/com/google/job/data/JobsDatabase.java
@@ -167,30 +167,5 @@ public final class JobsDatabase {
         };
 
         return ApiFutures.transform(querySnapshotFuture, function, MoreExecutors.directExecutor());
-
-//        // Runs an asynchronous transaction
-//        ApiFuture<Collection<Job>> futureTransaction = FireStoreUtils.getFireStore().runTransaction(transaction -> {
-//            ImmutableSet.Builder<Job> jobs = ImmutableSet.builder();
-//
-//            final Query activeJobsQuery = FireStoreUtils.getFireStore()
-//                .collection(JOB_COLLECTION)
-//                .whereEqualTo(JOB_STATUS_FIELD, JobStatus.ACTIVE);
-//
-//            List<QueryDocumentSnapshot> documents = transaction.get(activeJobsQuery).get().getDocuments();
-//
-//            for (DocumentSnapshot document : documents) {
-//                Job job = document.toObject(Job.class);
-//                List<String> requirements = job.getRequirements();
-//
-//                // Eligible job: all job requirements are contained in the applicant skills.
-//                if (skills.containsAll(requirements)) {
-//                    jobs.add(job);
-//                }
-//            }
-//
-//            return jobs.build();
-//        });
-//
-//        return futureTransaction;
     }
 }

--- a/walk-in-interview/src/main/java/com/google/job/data/JobsDatabase.java
+++ b/walk-in-interview/src/main/java/com/google/job/data/JobsDatabase.java
@@ -3,7 +3,7 @@ package com.google.job.data;
 import com.google.api.core.ApiFunction;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
-import com.google.appengine.repackaged.com.google.common.collect.ImmutableList;
+import com.google.appengine.repackaged.com.google.common.collect.ImmutableSet;
 import com.google.cloud.firestore.*;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.utils.FireStoreUtils;
@@ -145,7 +145,7 @@ public final class JobsDatabase {
     public Future<Collection<Job>> fetchAllEligibleJobs(List<String> skills) throws IOException {
         // Runs an asynchronous transaction
         ApiFuture<Collection<Job>> futureTransaction = FireStoreUtils.getFireStore().runTransaction(transaction -> {
-            ImmutableList.Builder<Job> jobs = ImmutableList.builder();
+            ImmutableSet.Builder<Job> jobs = ImmutableSet.builder();
 
             final Query activeJobsQuery = FireStoreUtils.getFireStore()
                 .collection(JOB_COLLECTION)

--- a/walk-in-interview/src/main/java/com/google/job/data/JobsDatabase.java
+++ b/walk-in-interview/src/main/java/com/google/job/data/JobsDatabase.java
@@ -5,7 +5,6 @@ import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
 import com.google.appengine.repackaged.com.google.common.collect.ImmutableSet;
 import com.google.cloud.firestore.*;
-import com.google.cloud.firestore.Query.Direction;
 import com.google.common.collect.ImmutableList; 
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.utils.FireStoreUtils;
@@ -17,7 +16,6 @@ import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.Future;
 import java.util.List;
-import java.io.IOException;
 
 /** Helps persist and retrieve job posts. */
 public final class JobsDatabase {

--- a/walk-in-interview/src/main/java/com/google/job/data/Requirement.java
+++ b/walk-in-interview/src/main/java/com/google/job/data/Requirement.java
@@ -3,6 +3,7 @@ package com.google.job.data;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -55,5 +56,14 @@ public enum Requirement {
         }
 
         return localizedNames.build();
+    }
+
+    /**
+     * Returns the localized names of the all requirements.
+     *
+     * @throw IllegalArgumentException If the language is not supported.
+     */
+    public static List<String> getAllLocalizedNames(String language) throws IllegalArgumentException {
+        return getLocalizedNames(Arrays.asList(Requirement.values()), language);
     }
 }

--- a/walk-in-interview/src/main/java/com/google/job/data/Requirement.java
+++ b/walk-in-interview/src/main/java/com/google/job/data/Requirement.java
@@ -27,6 +27,22 @@ public enum Requirement {
         return requirementId;
     }
 
+    /** Gets the requirement stable ids given enum value. */
+    public static List<String> getRequirementIds(List<Requirement> requirements) {
+        ImmutableList.Builder<String> requirementIds = ImmutableList.builder();
+        for (Requirement requirement: requirements) {
+            String id = requirement.getRequirementId();
+            requirementIds.add(id);
+        }
+
+        return requirementIds.build();
+    }
+
+    /** Returns the requirement stable ids of the all requirements. */
+    public static List<String> getAllRequirementIds() {
+        return getRequirementIds(Arrays.asList(Requirement.values()));
+    }
+
     /**
      * Gets the localized requirement name with the specified version of language.
      *

--- a/walk-in-interview/src/main/webapp/new-job/index.html
+++ b/walk-in-interview/src/main/webapp/new-job/index.html
@@ -58,8 +58,8 @@
         <!-- hidden div to be used as a template to render requirements list elements -->
         <div hidden>
             <li id="requirement-element-template">
-                <input type="checkbox" id="requirement-checkbox-template" name="requirements-list">
-                <label for="requirement-label-template">value</label>
+                <input type="checkbox" id="requirement-checkbox-template">
+                <label>value</label>
             </li>
         </div>
 

--- a/walk-in-interview/src/main/webapp/new-job/script.js
+++ b/walk-in-interview/src/main/webapp/new-job/script.js
@@ -161,7 +161,7 @@ function getJobDetailsFromUserInput() {
 
   const requirementsCheckboxes =
     document.getElementsByName('requirements-list');
-  const requirementsMap = [];
+  const requirementsMap = new Map();
   requirementsCheckboxes.forEach(({checked, id}) => {
     requirementsMap.set(id, checked);
   });

--- a/walk-in-interview/src/main/webapp/new-job/script.js
+++ b/walk-in-interview/src/main/webapp/new-job/script.js
@@ -108,6 +108,7 @@ function renderRequirementsList() {
       const checkbox = requirementElement.children[0];
       checkbox.setAttribute('id', key);
       checkbox.setAttribute('value', key);
+      checkbox.setAttribute('name', 'requirement');
 
       const label = requirementElement.children[1];
       label.setAttribute('for', key);
@@ -160,10 +161,10 @@ function getJobDetailsFromUserInput() {
   const payMax = document.getElementById('pay-max').valueAsNumber;
 
   const requirementsCheckboxes =
-    document.getElementsByName('requirements-list');
+    document.getElementsByName('requirement');
   const requirementsMap = new Map();
   requirementsCheckboxes.forEach(({checked, id}) => {
-    requirementsMap.set(id, checked);
+    requirementsMap[id] = checked;
   });
 
   const expiry = document.getElementById('expiry').valueAsNumber;

--- a/walk-in-interview/src/main/webapp/new-job/script.js
+++ b/walk-in-interview/src/main/webapp/new-job/script.js
@@ -164,7 +164,7 @@ function getJobDetailsFromUserInput() {
   const requirementsList = [];
   requirementsCheckboxes.forEach(({checked, id}) => {
     if (checked) {
-    requirementsList.push(id);
+      requirementsList.push(id);
     }
   });
 

--- a/walk-in-interview/src/main/webapp/new-job/script.js
+++ b/walk-in-interview/src/main/webapp/new-job/script.js
@@ -161,11 +161,9 @@ function getJobDetailsFromUserInput() {
 
   const requirementsCheckboxes =
     document.getElementsByName('requirements-list');
-  const requirementsList = [];
+  const requirementsMap = [];
   requirementsCheckboxes.forEach(({checked, id}) => {
-    if (checked) {
-      requirementsList.push(id);
-    }
+    requirementsMap.set(id, checked);
   });
 
   const expiry = document.getElementById('expiry').valueAsNumber;
@@ -185,7 +183,7 @@ function getJobDetailsFromUserInput() {
       min: payMin,
       max: payMax,
     },
-    requirements: requirementsList,
+    requirements: requirementsMap,
     postExpiryTimestamp: expiry,
     jobDuration: duration,
   };

--- a/walk-in-interview/src/main/webapp/update-job/index.html
+++ b/walk-in-interview/src/main/webapp/update-job/index.html
@@ -53,7 +53,7 @@
         <!-- hidden div to be used as a template to render requirements list elements -->
         <div hidden>
             <li id="requirement-element-template">
-                <input type="checkbox" id="requirement-checkbox-template" name="requirements-list">
+                <input type="checkbox" id="requirement-checkbox-template">
                 <label>value</label>
             </li>
         </div>

--- a/walk-in-interview/src/main/webapp/update-job/script.js
+++ b/walk-in-interview/src/main/webapp/update-job/script.js
@@ -202,7 +202,6 @@ function renderRequirementsList(requirements) {
     }
 
     const requirementElement = requirementElementTemplate.cloneNode(/* includes child elements */ true);
-    requirementElement.setAttribute('id', key);
 
     // tick box
     const checkbox = requirementElement.children[0];

--- a/walk-in-interview/src/main/webapp/update-job/script.js
+++ b/walk-in-interview/src/main/webapp/update-job/script.js
@@ -210,7 +210,7 @@ function renderRequirementsList(requirements) {
     checkbox.setAttribute('value', key);
 
     // If this requirement is one of the criteria for this job box, tick it
-    tickExistingRequirements(requirementsMap[key], requirements, checkbox);
+    tickExistingRequirements(key, requirements, checkbox);
 
     // text label
     const label = requirementElement.children[1];
@@ -471,7 +471,7 @@ function getJobForSeleniumTest() {
       min: 1,
       max: 4,
     },
-    requirements: ['O Level', 'English'],
+    requirements: ['O_LEVEL', 'LANGUAGE_ENGLISH'],
     postExpiryTimestamp: 1601856000000,
     jobDuration: 'ONE_WEEK',
   };

--- a/walk-in-interview/src/main/webapp/update-job/script.js
+++ b/walk-in-interview/src/main/webapp/update-job/script.js
@@ -287,7 +287,7 @@ function getJobDetailsFromUserInput() {
   
   const requirementsCheckboxes =
     document.getElementsByName('requirements-list');
-  const requirementsMap = [];
+  const requirementsMap = new Map();
   requirementsCheckboxes.forEach(({checked, id}) => {
     requirementsMap.set(id, checked);
   });

--- a/walk-in-interview/src/main/webapp/update-job/script.js
+++ b/walk-in-interview/src/main/webapp/update-job/script.js
@@ -208,9 +208,10 @@ function renderRequirementsList(requirements) {
     const checkbox = requirementElement.children[0];
     checkbox.setAttribute('id', key);
     checkbox.setAttribute('value', key);
+    checkbox.setAttribute('name', 'requirement');
 
     // If this requirement is one of the criteria for this job box, tick it
-    tickExistingRequirements(key, requirements, checkbox);
+    checkbox.setAttribute('checked', requirements.get(key));
 
     // text label
     const label = requirementElement.children[1];
@@ -218,19 +219,6 @@ function renderRequirementsList(requirements) {
     label.innerHTML = requirementsMap[key];
 
     requirementsListElement.appendChild(requirementElement);
-  }
-}
-
-/**
- * Ticks the existing requirement.
- * 
- * @param {String} requirement Requirement localized name.
- * @param {String} requirements Requirements list of current job post.
- * @param {HTMLElement} requirementElement HTML checkbox for that requirement
- */
-function tickExistingRequirements(requirement, requirements, requirementCheckbox) {
-  if (requirements.includes(requirement)) {
-    requirementCheckbox.setAttribute('checked', true);
   }
 }
 
@@ -296,11 +284,9 @@ function getJobDetailsFromUserInput() {
   
   const requirementsCheckboxes =
     document.getElementsByName('requirements-list');
-  const requirementsList = [];
+  const requirementsMap = [];
   requirementsCheckboxes.forEach(({checked, id}) => {
-    if (checked) {
-      requirementsList.push(id);
-    }
+    requirementsMap.set(id, checked);
   });
   
   const expiry = document.getElementById('expiry').valueAsNumber;
@@ -328,7 +314,7 @@ function getJobDetailsFromUserInput() {
       min: payMin,
       max: payMax,
     },
-    requirements: requirementsList,
+    requirements: requirementsMap,
     postExpiryTimestamp: expiry,
     jobDuration: duration,
   };
@@ -471,7 +457,11 @@ function getJobForSeleniumTest() {
       min: 1,
       max: 4,
     },
-    requirements: ['O_LEVEL', 'LANGUAGE_ENGLISH'],
+    requirements: {
+      'O_LEVEL': true,
+      'LANGUAGE_ENGLISH': true,
+      'DRIVING_LICENSE_C': false,
+    },
     postExpiryTimestamp: 1601856000000,
     jobDuration: 'ONE_WEEK',
   };

--- a/walk-in-interview/src/main/webapp/update-job/script.js
+++ b/walk-in-interview/src/main/webapp/update-job/script.js
@@ -211,7 +211,10 @@ function renderRequirementsList(requirements) {
     checkbox.setAttribute('name', 'requirement');
 
     // If this requirement is one of the criteria for this job box, tick it
-    checkbox.setAttribute('checked', requirements.get(key));
+    const selected = requirements[key];
+    if (selected) {
+      checkbox.setAttribute('checked', requirements[key]);
+    }
 
     // text label
     const label = requirementElement.children[1];

--- a/walk-in-interview/src/main/webapp/update-job/script.js
+++ b/walk-in-interview/src/main/webapp/update-job/script.js
@@ -286,10 +286,10 @@ function getJobDetailsFromUserInput() {
   const payMax = document.getElementById('pay-max').valueAsNumber;
   
   const requirementsCheckboxes =
-    document.getElementsByName('requirements-list');
+    document.getElementsByName('requirement');
   const requirementsMap = new Map();
   requirementsCheckboxes.forEach(({checked, id}) => {
-    requirementsMap.set(id, checked);
+    requirementsMap[id] = checked;
   });
   
   const expiry = document.getElementById('expiry').valueAsNumber;

--- a/walk-in-interview/src/test/java/com/google/job/data/JobsDatabaseTest.java
+++ b/walk-in-interview/src/test/java/com/google/job/data/JobsDatabaseTest.java
@@ -269,7 +269,7 @@ public final class JobsDatabaseTest {
                 .setJobDuration(jobDuration)
                 .build();
 
-        firestore.collection("JobsForEligibilityTest").add(job1);
+        firestore.collection(TEST_JOB_COLLECTION).add(job1);
 
         requirements = Requirement.getLocalizedNames(Arrays.asList(O_LEVEL, ENGLISH), "en");
 
@@ -299,7 +299,7 @@ public final class JobsDatabaseTest {
                 .setJobDuration(jobDuration)
                 .build();
 
-        firestore.collection("JobsForEligibilityTest").add(job3);
+        firestore.collection(TEST_JOB_COLLECTION).add(job3);
 
         requirements = Requirement.getLocalizedNames(Arrays.asList(O_LEVEL, ENGLISH, DRIVING_LICENSE_C), "en");
 
@@ -314,7 +314,7 @@ public final class JobsDatabaseTest {
                 .setJobDuration(jobDuration)
                 .build();
 
-        firestore.collection("JobsForEligibilityTest").add(job4);
+        firestore.collection(TEST_JOB_COLLECTION).add(job4);
 
         requirements = Requirement.getLocalizedNames(Arrays.asList(ENGLISH), "en");
 
@@ -329,7 +329,7 @@ public final class JobsDatabaseTest {
                 .setJobDuration(jobDuration)
                 .build();
 
-        firestore.collection("JobsForEligibilityTest").add(job5);
+        firestore.collection(TEST_JOB_COLLECTION        ).add(job5);
 
         List<String> skills = Requirement.getLocalizedNames(Arrays.asList(O_LEVEL, ENGLISH), "en");
 

--- a/walk-in-interview/src/test/java/com/google/job/data/JobsDatabaseTest.java
+++ b/walk-in-interview/src/test/java/com/google/job/data/JobsDatabaseTest.java
@@ -55,8 +55,7 @@ public final class JobsDatabaseTest {
         Location expectedLocation =  new Location("Google", "123456", 0, 0);
         String expectedJobDescription = "Programming using java";
         JobPayment expectedJobPayment = new JobPayment(0, 5000, PaymentFrequency.MONTHLY);
-        List<String> expectedRequirements = Requirement.getLocalizedNames(
-                Arrays.asList(DRIVING_LICENSE_C, O_LEVEL, ENGLISH), "en");
+        List<Requirement> expectedRequirements = Arrays.asList(DRIVING_LICENSE_C, O_LEVEL, ENGLISH);
         long expectedPostExpiry = System.currentTimeMillis();
         JobDuration expectedJobDuration = JobDuration.SIX_MONTHS;
 
@@ -110,8 +109,7 @@ public final class JobsDatabaseTest {
         Location expectedLocation =  new Location("Google", "123456", 0, 0);
         String expectedJobDescription = "New employee";
         JobPayment expectedJobPayment = new JobPayment(0, 5000, PaymentFrequency.MONTHLY);
-        List<String> expectedRequirements = Requirement.getLocalizedNames(
-                Arrays.asList(O_LEVEL, ENGLISH), "en");
+        List<Requirement> expectedRequirements = Arrays.asList(O_LEVEL, ENGLISH);
         long expectedPostExpiry = System.currentTimeMillis();
         JobDuration expectedJobDuration = JobDuration.ONE_MONTH;
 
@@ -210,7 +208,7 @@ public final class JobsDatabaseTest {
         Location expectedLocation =  new Location("Maple Tree", "123456", 0, 0);
         String expectedJobDescription = "Fighting to defeat hair line recede";
         JobPayment expectedJobPayment = new JobPayment(0, 5000, PaymentFrequency.MONTHLY);
-        List<String> expectedRequirements = Requirement.getLocalizedNames(Arrays.asList(O_LEVEL), "en");
+        List<Requirement> expectedRequirements = Arrays.asList(O_LEVEL);
         long expectedPostExpiry = System.currentTimeMillis();;
         JobDuration expectedJobDuration = JobDuration.ONE_MONTH;
 
@@ -249,27 +247,27 @@ public final class JobsDatabaseTest {
     @Test
     public void fetchAllEligibleJobs_normalInput_success() throws IOException, ExecutionException, InterruptedException {
         // Arrange.
-        List<String> requirements = Requirement.getLocalizedNames(Arrays.asList(O_LEVEL), "en");
+        List<Requirement> requirements = Arrays.asList(O_LEVEL);
 
         Job job1 = testJobDataCreation(JobStatus.ACTIVE, requirements);
 
-        requirements = Requirement.getLocalizedNames(Arrays.asList(O_LEVEL, ENGLISH), "en");
+        requirements = Arrays.asList(O_LEVEL, ENGLISH);
 
         Job job2 = testJobDataCreation(JobStatus.ACTIVE, requirements);
 
-        requirements = Requirement.getLocalizedNames(Arrays.asList(ENGLISH, DRIVING_LICENSE_C), "en");
+        requirements = Arrays.asList(ENGLISH, DRIVING_LICENSE_C);
 
         Job job3 = testJobDataCreation(JobStatus.ACTIVE, requirements);
 
-        requirements = Requirement.getLocalizedNames(Arrays.asList(O_LEVEL, ENGLISH, DRIVING_LICENSE_C), "en");
+        requirements = Arrays.asList(O_LEVEL, ENGLISH, DRIVING_LICENSE_C);
 
         Job job4 = testJobDataCreation(JobStatus.ACTIVE, requirements);
 
-        requirements = Requirement.getLocalizedNames(Arrays.asList(ENGLISH), "en");
+        requirements = Arrays.asList(ENGLISH);
 
         Job job5 = testJobDataCreation(JobStatus.ACTIVE, requirements);
 
-        List<String> skills = Requirement.getLocalizedNames(Arrays.asList(O_LEVEL, ENGLISH), "en");
+        List<Requirement> skills = Arrays.asList(O_LEVEL, ENGLISH);
 
         // Act.
         Future<Collection<Job>> jobsFuture = jobsDatabase.fetchAllEligibleJobs(skills);
@@ -283,27 +281,27 @@ public final class JobsDatabaseTest {
     @Test
     public void fetchAllEligibleJobs_noJobMatch_noJobSelected() throws IOException, ExecutionException, InterruptedException {
         // Arrange.
-        List<String> requirements = Requirement.getLocalizedNames(Arrays.asList(O_LEVEL), "en");
+        List<Requirement> requirements = Arrays.asList(O_LEVEL);
 
         Job job1 = testJobDataCreation(JobStatus.ACTIVE, requirements);
 
-        requirements = Requirement.getLocalizedNames(Arrays.asList(O_LEVEL, ENGLISH), "en");
+        requirements = Arrays.asList(O_LEVEL, ENGLISH);
 
         Job job2 = testJobDataCreation(JobStatus.ACTIVE, requirements);
 
-        requirements = Requirement.getLocalizedNames(Arrays.asList(ENGLISH, DRIVING_LICENSE_C), "en");
+        requirements = Arrays.asList(ENGLISH, DRIVING_LICENSE_C);
 
         Job job3 = testJobDataCreation(JobStatus.ACTIVE, requirements);
 
-        requirements = Requirement.getLocalizedNames(Arrays.asList(O_LEVEL, ENGLISH, DRIVING_LICENSE_C), "en");
+        requirements = Arrays.asList(O_LEVEL, ENGLISH, DRIVING_LICENSE_C);
 
         Job job4 = testJobDataCreation(JobStatus.ACTIVE, requirements);
 
-        requirements = Requirement.getLocalizedNames(Arrays.asList(ENGLISH), "en");
+        requirements = Arrays.asList(ENGLISH);
 
         Job job5 = testJobDataCreation(JobStatus.ACTIVE, requirements);
 
-        List<String> skills = Requirement.getLocalizedNames(Arrays.asList(DRIVING_LICENSE_C), "en");
+        List<Requirement> skills = Arrays.asList(DRIVING_LICENSE_C);
 
         // Act.
         Future<Collection<Job>> jobsFuture = jobsDatabase.fetchAllEligibleJobs(skills);
@@ -318,27 +316,27 @@ public final class JobsDatabaseTest {
     public void fetchAllEligibleJobs_hasDeletedJob_deletedJobNotSelected()
             throws IOException, ExecutionException, InterruptedException {
         // Arrange.
-        List<String> requirements = Requirement.getLocalizedNames(Arrays.asList(O_LEVEL), "en");
+        List<Requirement> requirements = Arrays.asList(O_LEVEL);
 
         Job job1 = testJobDataCreation(JobStatus.ACTIVE, requirements);
 
-        requirements = Requirement.getLocalizedNames(Arrays.asList(O_LEVEL, ENGLISH), "en");
+        requirements = Arrays.asList(O_LEVEL, ENGLISH);
 
         Job job2 = testJobDataCreation(JobStatus.DELETED, requirements);
 
-        requirements = Requirement.getLocalizedNames(Arrays.asList(ENGLISH, DRIVING_LICENSE_C), "en");
+        requirements = Arrays.asList(ENGLISH, DRIVING_LICENSE_C);
 
         Job job3 = testJobDataCreation(JobStatus.ACTIVE, requirements);
 
-        requirements = Requirement.getLocalizedNames(Arrays.asList(O_LEVEL, ENGLISH, DRIVING_LICENSE_C), "en");
+        requirements = Arrays.asList(O_LEVEL, ENGLISH, DRIVING_LICENSE_C);
 
         Job job4 = testJobDataCreation(JobStatus.ACTIVE, requirements);
 
-        requirements = Requirement.getLocalizedNames(Arrays.asList(ENGLISH), "en");
+        requirements = Arrays.asList(ENGLISH);
 
         Job job5 = testJobDataCreation(JobStatus.ACTIVE, requirements);
 
-        List<String> skills = Requirement.getLocalizedNames(Arrays.asList(O_LEVEL, ENGLISH), "en");
+        List<Requirement> skills = Arrays.asList(O_LEVEL, ENGLISH);
 
         // Act.
         Future<Collection<Job>> jobsFuture = jobsDatabase.fetchAllEligibleJobs(skills);
@@ -349,7 +347,7 @@ public final class JobsDatabaseTest {
         assertEquals(expectedJobs, actualJobs);
     }
 
-    private Job testJobDataCreation(JobStatus jobStatus, List<String> requirements)
+    private Job testJobDataCreation(JobStatus jobStatus, List<Requirement> requirements)
             throws ExecutionException, InterruptedException {
         String jobName = "Programmer";
         Location location =  new Location("Maple Tree", "123456", 0, 0);

--- a/walk-in-interview/src/test/java/com/google/job/data/JobsDatabaseTest.java
+++ b/walk-in-interview/src/test/java/com/google/job/data/JobsDatabaseTest.java
@@ -348,7 +348,7 @@ public final class JobsDatabaseTest {
     }
 
     @Test
-    public void fetchAllEligibleJobs_noJobMatch_success() throws IOException, ExecutionException, InterruptedException {
+    public void fetchAllEligibleJobs_noJobMatch_noJobSelected() throws IOException, ExecutionException, InterruptedException {
         // Arrange.
         JobStatus jobStatus = JobStatus.ACTIVE;
         String jobName = "Programmer";
@@ -444,6 +444,108 @@ public final class JobsDatabaseTest {
 
         // Assert.
         Collection<Job> expectedJobs = new HashSet<>();
+        Collection<Job> actualJobs = jobsFuture.get();
+        assertEquals(expectedJobs, actualJobs);
+    }
+
+    @Test
+    public void fetchAllEligibleJobs_hasDeletedJob_deletedJobNotSelected()
+            throws IOException, ExecutionException, InterruptedException {
+        // Arrange.
+        JobStatus jobStatus = JobStatus.ACTIVE;
+        String jobName = "Programmer";
+        Location location =  new Location("Maple Tree", "123456", 0, 0);
+        String jobDescription = "Fighting to defeat hair line recede";
+        JobPayment jobPayment = new JobPayment(0, 5000, PaymentFrequency.MONTHLY);
+        List<String> requirements = Requirement.getLocalizedNames(Arrays.asList(O_LEVEL), "en");
+        long postExpiry = System.currentTimeMillis();;
+        JobDuration jobDuration = JobDuration.ONE_MONTH;
+
+        Job job1 = Job.newBuilder()
+                .setJobStatus(jobStatus)
+                .setJobTitle(jobName)
+                .setLocation(location)
+                .setJobDescription(jobDescription)
+                .setJobPay(jobPayment)
+                .setRequirements(requirements)
+                .setPostExpiry(postExpiry)
+                .setJobDuration(jobDuration)
+                .build();
+
+        // future.get() blocks on response.
+        firestore.collection(TEST_JOB_COLLECTION).add(job1).get();
+
+        requirements = Requirement.getLocalizedNames(Arrays.asList(O_LEVEL, ENGLISH), "en");
+
+        Job job2 = Job.newBuilder()
+                .setJobStatus(JobStatus.DELETED)
+                .setJobTitle(jobName)
+                .setLocation(location)
+                .setJobDescription(jobDescription)
+                .setJobPay(jobPayment)
+                .setRequirements(requirements)
+                .setPostExpiry(postExpiry)
+                .setJobDuration(jobDuration)
+                .build();
+
+        // future.get() blocks on response.
+        firestore.collection(TEST_JOB_COLLECTION).add(job2).get();
+
+        requirements = Requirement.getLocalizedNames(Arrays.asList(ENGLISH, DRIVING_LICENSE_C), "en");
+
+        Job job3 = Job.newBuilder()
+                .setJobStatus(jobStatus)
+                .setJobTitle(jobName)
+                .setLocation(location)
+                .setJobDescription(jobDescription)
+                .setJobPay(jobPayment)
+                .setRequirements(requirements)
+                .setPostExpiry(postExpiry)
+                .setJobDuration(jobDuration)
+                .build();
+
+        // future.get() blocks on response.
+        firestore.collection(TEST_JOB_COLLECTION).add(job3).get();
+
+        requirements = Requirement.getLocalizedNames(Arrays.asList(O_LEVEL, ENGLISH, DRIVING_LICENSE_C), "en");
+
+        Job job4 = Job.newBuilder()
+                .setJobStatus(jobStatus)
+                .setJobTitle(jobName)
+                .setLocation(location)
+                .setJobDescription(jobDescription)
+                .setJobPay(jobPayment)
+                .setRequirements(requirements)
+                .setPostExpiry(postExpiry)
+                .setJobDuration(jobDuration)
+                .build();
+
+        // future.get() blocks on response.
+        firestore.collection(TEST_JOB_COLLECTION).add(job4).get();
+
+        requirements = Requirement.getLocalizedNames(Arrays.asList(ENGLISH), "en");
+
+        Job job5 = Job.newBuilder()
+                .setJobStatus(jobStatus)
+                .setJobTitle(jobName)
+                .setLocation(location)
+                .setJobDescription(jobDescription)
+                .setJobPay(jobPayment)
+                .setRequirements(requirements)
+                .setPostExpiry(postExpiry)
+                .setJobDuration(jobDuration)
+                .build();
+
+        // future.get() blocks on response.
+        firestore.collection(TEST_JOB_COLLECTION).add(job5).get();
+
+        List<String> skills = Requirement.getLocalizedNames(Arrays.asList(O_LEVEL, ENGLISH), "en");
+
+        // Act.
+        Future<Collection<Job>> jobsFuture = jobsDatabase.fetchAllEligibleJobs(skills);
+
+        // Assert.
+        Collection<Job> expectedJobs = new HashSet<>(Arrays.asList(job1, job5));
         Collection<Job> actualJobs = jobsFuture.get();
         assertEquals(expectedJobs, actualJobs);
     }

--- a/walk-in-interview/src/test/java/com/google/job/data/JobsDatabaseTest.java
+++ b/walk-in-interview/src/test/java/com/google/job/data/JobsDatabaseTest.java
@@ -1,7 +1,7 @@
 package com.google.job.data;
 
 import com.google.api.core.ApiFuture;
-import com.google.appengine.repackaged.com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMap;
 import com.google.cloud.firestore.*;
 import com.google.utils.FireStoreUtils;
 import org.junit.*;
@@ -56,8 +56,10 @@ public final class JobsDatabaseTest {
         Location expectedLocation =  new Location("Google", "123456", 0, 0);
         String expectedJobDescription = "Programming using java";
         JobPayment expectedJobPayment = new JobPayment(0, 5000, PaymentFrequency.MONTHLY);
-        Map<String, Boolean> expectedRequirements = ImmutableMap.of(DRIVING_LICENSE_C.getRequirementId(), true,
-                O_LEVEL.getRequirementId(), true, ENGLISH.getRequirementId(), true);
+        Map<String, Boolean> expectedRequirements = ImmutableMap.of(
+                                                        DRIVING_LICENSE_C.getRequirementId(), true,
+                                                        O_LEVEL.getRequirementId(), true,
+                                                        ENGLISH.getRequirementId(), true);
         long expectedPostExpiry = System.currentTimeMillis();
         JobDuration expectedJobDuration = JobDuration.SIX_MONTHS;
 
@@ -111,8 +113,10 @@ public final class JobsDatabaseTest {
         Location expectedLocation =  new Location("Google", "123456", 0, 0);
         String expectedJobDescription = "New employee";
         JobPayment expectedJobPayment = new JobPayment(0, 5000, PaymentFrequency.MONTHLY);
-        Map<String, Boolean> expectedRequirements = ImmutableMap.of(DRIVING_LICENSE_C.getRequirementId(), false,
-                O_LEVEL.getRequirementId(), true, ENGLISH.getRequirementId(), true);
+        Map<String, Boolean> expectedRequirements = ImmutableMap.of(
+                                                        DRIVING_LICENSE_C.getRequirementId(), false,
+                                                        O_LEVEL.getRequirementId(), true,
+                                                        ENGLISH.getRequirementId(), true);
         long expectedPostExpiry = System.currentTimeMillis();
         JobDuration expectedJobDuration = JobDuration.ONE_MONTH;
 
@@ -211,9 +215,11 @@ public final class JobsDatabaseTest {
         Location expectedLocation =  new Location("Maple Tree", "123456", 0, 0);
         String expectedJobDescription = "Fighting to defeat hair line recede";
         JobPayment expectedJobPayment = new JobPayment(0, 5000, PaymentFrequency.MONTHLY);
-        Map<String, Boolean> expectedRequirements = ImmutableMap.of(DRIVING_LICENSE_C.getRequirementId(), false,
-                O_LEVEL.getRequirementId(), true, ENGLISH.getRequirementId(), false);
-        long expectedPostExpiry = System.currentTimeMillis();;
+        Map<String, Boolean> expectedRequirements = ImmutableMap.of(
+                                                        DRIVING_LICENSE_C.getRequirementId(), false,
+                                                        O_LEVEL.getRequirementId(), true,
+                                                        ENGLISH.getRequirementId(), false);
+        long expectedPostExpiry = System.currentTimeMillis();
         JobDuration expectedJobDuration = JobDuration.ONE_MONTH;
 
         Job job = Job.newBuilder()
@@ -251,25 +257,35 @@ public final class JobsDatabaseTest {
     @Test
     public void fetchAllEligibleJobs_normalInput_success() throws IOException, ExecutionException, InterruptedException {
         // Arrange.
-        Map<String, Boolean> requirements = ImmutableMap.of(DRIVING_LICENSE_C.getRequirementId(), false,
-                O_LEVEL.getRequirementId(), true, ENGLISH.getRequirementId(), false);
-        Job job1 = testJobDataCreation(JobStatus.ACTIVE, requirements);
+        Map<String, Boolean> requirements = ImmutableMap.of(
+                                                DRIVING_LICENSE_C.getRequirementId(), false,
+                                                O_LEVEL.getRequirementId(), true,
+                                                ENGLISH.getRequirementId(), false);
+        Job job1 = requirementFileterTestJobDataCreation(JobStatus.ACTIVE, requirements);
 
-        requirements = ImmutableMap.of(DRIVING_LICENSE_C.getRequirementId(), false,
-                O_LEVEL.getRequirementId(), true, ENGLISH.getRequirementId(), true);
-        Job job2 = testJobDataCreation(JobStatus.ACTIVE, requirements);
+        requirements = ImmutableMap.of(
+                DRIVING_LICENSE_C.getRequirementId(), false,
+                O_LEVEL.getRequirementId(), true,
+                ENGLISH.getRequirementId(), true);
+        Job job2 = requirementFileterTestJobDataCreation(JobStatus.ACTIVE, requirements);
 
-        requirements = ImmutableMap.of(DRIVING_LICENSE_C.getRequirementId(), true,
-                O_LEVEL.getRequirementId(), false, ENGLISH.getRequirementId(), true);
-        Job job3 = testJobDataCreation(JobStatus.ACTIVE, requirements);
+        requirements = ImmutableMap.of(
+                DRIVING_LICENSE_C.getRequirementId(), true,
+                O_LEVEL.getRequirementId(), false,
+                ENGLISH.getRequirementId(), true);
+        Job job3 = requirementFileterTestJobDataCreation(JobStatus.ACTIVE, requirements);
 
-        requirements = ImmutableMap.of(DRIVING_LICENSE_C.getRequirementId(), true,
-                O_LEVEL.getRequirementId(), true, ENGLISH.getRequirementId(), true);;
-        Job job4 = testJobDataCreation(JobStatus.ACTIVE, requirements);
+        requirements = ImmutableMap.of(
+                DRIVING_LICENSE_C.getRequirementId(), true,
+                O_LEVEL.getRequirementId(), true,
+                ENGLISH.getRequirementId(), true);
+        Job job4 = requirementFileterTestJobDataCreation(JobStatus.ACTIVE, requirements);
 
-        requirements = ImmutableMap.of(DRIVING_LICENSE_C.getRequirementId(), false,
-                O_LEVEL.getRequirementId(), false, ENGLISH.getRequirementId(), true);;
-        Job job5 = testJobDataCreation(JobStatus.ACTIVE, requirements);
+        requirements = ImmutableMap.of(
+                DRIVING_LICENSE_C.getRequirementId(), false,
+                O_LEVEL.getRequirementId(), false,
+                ENGLISH.getRequirementId(), true);
+        Job job5 = requirementFileterTestJobDataCreation(JobStatus.ACTIVE, requirements);
 
         List<String> skills = Requirement.getRequirementIds(Arrays.asList(O_LEVEL, ENGLISH));
 
@@ -285,25 +301,35 @@ public final class JobsDatabaseTest {
     @Test
     public void fetchAllEligibleJobs_noJobMatch_noJobSelected() throws IOException, ExecutionException, InterruptedException {
         // Arrange.
-        Map<String, Boolean> requirements = ImmutableMap.of(DRIVING_LICENSE_C.getRequirementId(), false,
-                O_LEVEL.getRequirementId(), true, ENGLISH.getRequirementId(), false);
-        Job job1 = testJobDataCreation(JobStatus.ACTIVE, requirements);
+        Map<String, Boolean> requirements = ImmutableMap.of(
+                                                DRIVING_LICENSE_C.getRequirementId(), false,
+                                                O_LEVEL.getRequirementId(), true,
+                                                ENGLISH.getRequirementId(), false);
+        Job job1 = requirementFileterTestJobDataCreation(JobStatus.ACTIVE, requirements);
 
-        requirements = ImmutableMap.of(DRIVING_LICENSE_C.getRequirementId(), false,
-                O_LEVEL.getRequirementId(), true, ENGLISH.getRequirementId(), true);
-        Job job2 = testJobDataCreation(JobStatus.ACTIVE, requirements);
+        requirements = ImmutableMap.of(
+                DRIVING_LICENSE_C.getRequirementId(), false,
+                O_LEVEL.getRequirementId(), true,
+                ENGLISH.getRequirementId(), true);
+        Job job2 = requirementFileterTestJobDataCreation(JobStatus.ACTIVE, requirements);
 
-        requirements = ImmutableMap.of(DRIVING_LICENSE_C.getRequirementId(), true,
-                O_LEVEL.getRequirementId(), false, ENGLISH.getRequirementId(), true);
-        Job job3 = testJobDataCreation(JobStatus.ACTIVE, requirements);
+        requirements = ImmutableMap.of(
+                DRIVING_LICENSE_C.getRequirementId(), true,
+                O_LEVEL.getRequirementId(), false,
+                ENGLISH.getRequirementId(), true);
+        Job job3 = requirementFileterTestJobDataCreation(JobStatus.ACTIVE, requirements);
 
-        requirements = ImmutableMap.of(DRIVING_LICENSE_C.getRequirementId(), true,
-                O_LEVEL.getRequirementId(), true, ENGLISH.getRequirementId(), true);;
-        Job job4 = testJobDataCreation(JobStatus.ACTIVE, requirements);
+        requirements = ImmutableMap.of(
+                DRIVING_LICENSE_C.getRequirementId(), true,
+                O_LEVEL.getRequirementId(), true,
+                ENGLISH.getRequirementId(), true);
+        Job job4 = requirementFileterTestJobDataCreation(JobStatus.ACTIVE, requirements);
 
-        requirements = ImmutableMap.of(DRIVING_LICENSE_C.getRequirementId(), false,
-                O_LEVEL.getRequirementId(), false, ENGLISH.getRequirementId(), true);;
-        Job job5 = testJobDataCreation(JobStatus.ACTIVE, requirements);
+        requirements = ImmutableMap.of(
+                DRIVING_LICENSE_C.getRequirementId(), false,
+                O_LEVEL.getRequirementId(), false,
+                ENGLISH.getRequirementId(), true);
+        Job job5 = requirementFileterTestJobDataCreation(JobStatus.ACTIVE, requirements);
 
         List<String> skills = Requirement.getRequirementIds(Arrays.asList(DRIVING_LICENSE_C));
 
@@ -320,25 +346,35 @@ public final class JobsDatabaseTest {
     public void fetchAllEligibleJobs_hasDeletedJob_deletedJobNotSelected()
             throws IOException, ExecutionException, InterruptedException {
         // Arrange.
-        Map<String, Boolean> requirements = ImmutableMap.of(DRIVING_LICENSE_C.getRequirementId(), false,
-                O_LEVEL.getRequirementId(), true, ENGLISH.getRequirementId(), false);
-        Job job1 = testJobDataCreation(JobStatus.ACTIVE, requirements);
+        Map<String, Boolean> requirements = ImmutableMap.of(
+                                                DRIVING_LICENSE_C.getRequirementId(), false,
+                                                O_LEVEL.getRequirementId(), true,
+                                                ENGLISH.getRequirementId(), false);
+        Job job1 = requirementFileterTestJobDataCreation(JobStatus.ACTIVE, requirements);
 
-        requirements = ImmutableMap.of(DRIVING_LICENSE_C.getRequirementId(), false,
-                O_LEVEL.getRequirementId(), true, ENGLISH.getRequirementId(), true);
-        Job job2 = testJobDataCreation(JobStatus.DELETED, requirements);
+        requirements = ImmutableMap.of(
+                DRIVING_LICENSE_C.getRequirementId(), false,
+                O_LEVEL.getRequirementId(), true,
+                ENGLISH.getRequirementId(), true);
+        Job job2 = requirementFileterTestJobDataCreation(JobStatus.DELETED, requirements);
 
-        requirements = ImmutableMap.of(DRIVING_LICENSE_C.getRequirementId(), true,
-                O_LEVEL.getRequirementId(), false, ENGLISH.getRequirementId(), true);
-        Job job3 = testJobDataCreation(JobStatus.ACTIVE, requirements);
+        requirements = ImmutableMap.of(
+                DRIVING_LICENSE_C.getRequirementId(), true,
+                O_LEVEL.getRequirementId(), false,
+                ENGLISH.getRequirementId(), true);
+        Job job3 = requirementFileterTestJobDataCreation(JobStatus.ACTIVE, requirements);
 
-        requirements = ImmutableMap.of(DRIVING_LICENSE_C.getRequirementId(), true,
-                O_LEVEL.getRequirementId(), true, ENGLISH.getRequirementId(), true);;
-        Job job4 = testJobDataCreation(JobStatus.ACTIVE, requirements);
+        requirements = ImmutableMap.of(
+                DRIVING_LICENSE_C.getRequirementId(), true,
+                O_LEVEL.getRequirementId(), true,
+                ENGLISH.getRequirementId(), true);
+        Job job4 = requirementFileterTestJobDataCreation(JobStatus.ACTIVE, requirements);
 
-        requirements = ImmutableMap.of(DRIVING_LICENSE_C.getRequirementId(), false,
-                O_LEVEL.getRequirementId(), false, ENGLISH.getRequirementId(), true);;
-        Job job5 = testJobDataCreation(JobStatus.ACTIVE, requirements);
+        requirements = ImmutableMap.of(
+                DRIVING_LICENSE_C.getRequirementId(), false,
+                O_LEVEL.getRequirementId(), false,
+                ENGLISH.getRequirementId(), true);
+        Job job5 = requirementFileterTestJobDataCreation(JobStatus.ACTIVE, requirements);
 
         List<String> skills = Requirement.getRequirementIds(Arrays.asList(O_LEVEL, ENGLISH));
 
@@ -351,13 +387,13 @@ public final class JobsDatabaseTest {
         assertEquals(expectedJobs, actualJobs);
     }
 
-    private Job testJobDataCreation(JobStatus jobStatus, Map<String, Boolean> requirements)
+    private Job requirementFileterTestJobDataCreation(JobStatus jobStatus, Map<String, Boolean> requirements)
             throws ExecutionException, InterruptedException {
         String jobName = "Programmer";
         Location location =  new Location("Maple Tree", "123456", 0, 0);
         String jobDescription = "Fighting to defeat hair line recede";
         JobPayment jobPayment = new JobPayment(0, 5000, PaymentFrequency.MONTHLY);
-        long postExpiry = System.currentTimeMillis();;
+        long postExpiry = System.currentTimeMillis();
         JobDuration jobDuration = JobDuration.ONE_MONTH;
 
         Job job = Job.newBuilder()

--- a/walk-in-interview/src/test/java/com/google/job/data/JobsDatabaseTest.java
+++ b/walk-in-interview/src/test/java/com/google/job/data/JobsDatabaseTest.java
@@ -168,7 +168,8 @@ public final class JobsDatabaseTest {
     }
 
     @Test
-    public void markJobPostAsDeleted_normalInput_success() throws ExecutionException, InterruptedException, IOException {
+    public void markJobPostAsDeleted_normalInput_success()
+            throws ExecutionException, InterruptedException, IOException {
         // Arrange.
         Job job = new Job();
         Future<DocumentReference> addedJobFuture = firestore.collection(TEST_JOB_COLLECTION).add(job);
@@ -243,6 +244,102 @@ public final class JobsDatabaseTest {
         Job actualJob = jobOptional.get();
 
         assertEquals(job, actualJob);
+    }
+
+    @Test
+    public void fetchAllEligibleJobs_normalInput_success() throws IOException, ExecutionException, InterruptedException {
+        // Arrange.
+        JobStatus jobStatus = JobStatus.ACTIVE;
+        String jobName = "Programmer";
+        Location location =  new Location("Maple Tree", "123456", 0, 0);
+        String jobDescription = "Fighting to defeat hair line recede";
+        JobPayment jobPayment = new JobPayment(0, 5000, PaymentFrequency.MONTHLY);
+        List<String> requirements = Requirement.getLocalizedNames(Arrays.asList(O_LEVEL), "en");
+        long postExpiry = System.currentTimeMillis();;
+        JobDuration jobDuration = JobDuration.ONE_MONTH;
+
+        Job job1 = Job.newBuilder()
+                .setJobStatus(jobStatus)
+                .setJobTitle(jobName)
+                .setLocation(location)
+                .setJobDescription(jobDescription)
+                .setJobPay(jobPayment)
+                .setRequirements(requirements)
+                .setPostExpiry(postExpiry)
+                .setJobDuration(jobDuration)
+                .build();
+
+        firestore.collection("JobsForEligibilityTest").add(job1);
+
+        requirements = Requirement.getLocalizedNames(Arrays.asList(O_LEVEL, ENGLISH), "en");
+
+        Job job2 = Job.newBuilder()
+            .setJobStatus(jobStatus)
+            .setJobTitle(jobName)
+            .setLocation(location)
+            .setJobDescription(jobDescription)
+            .setJobPay(jobPayment)
+            .setRequirements(requirements)
+            .setPostExpiry(postExpiry)
+            .setJobDuration(jobDuration)
+            .build();
+
+        firestore.collection("JobsForEligibilityTest").add(job2);
+
+        requirements = Requirement.getLocalizedNames(Arrays.asList(ENGLISH, DRIVING_LICENSE_C), "en");
+
+        Job job3 = Job.newBuilder()
+                .setJobStatus(jobStatus)
+                .setJobTitle(jobName)
+                .setLocation(location)
+                .setJobDescription(jobDescription)
+                .setJobPay(jobPayment)
+                .setRequirements(requirements)
+                .setPostExpiry(postExpiry)
+                .setJobDuration(jobDuration)
+                .build();
+
+        firestore.collection("JobsForEligibilityTest").add(job3);
+
+        requirements = Requirement.getLocalizedNames(Arrays.asList(O_LEVEL, ENGLISH, DRIVING_LICENSE_C), "en");
+
+        Job job4 = Job.newBuilder()
+                .setJobStatus(jobStatus)
+                .setJobTitle(jobName)
+                .setLocation(location)
+                .setJobDescription(jobDescription)
+                .setJobPay(jobPayment)
+                .setRequirements(requirements)
+                .setPostExpiry(postExpiry)
+                .setJobDuration(jobDuration)
+                .build();
+
+        firestore.collection("JobsForEligibilityTest").add(job4);
+
+        requirements = Requirement.getLocalizedNames(Arrays.asList(ENGLISH), "en");
+
+        Job job5 = Job.newBuilder()
+                .setJobStatus(jobStatus)
+                .setJobTitle(jobName)
+                .setLocation(location)
+                .setJobDescription(jobDescription)
+                .setJobPay(jobPayment)
+                .setRequirements(requirements)
+                .setPostExpiry(postExpiry)
+                .setJobDuration(jobDuration)
+                .build();
+
+        firestore.collection("JobsForEligibilityTest").add(job5);
+
+        List<String> skills = Requirement.getLocalizedNames(Arrays.asList(O_LEVEL, ENGLISH), "en");
+
+        // Act.
+        Future<Collection<Job>> future = jobsDatabase.fetchAllEligibleJobs(skills);
+
+        // Assert.
+        Collection<Job> expectedJobs = Arrays.asList(job1, job2, job5);
+        Collection<Job> actualJobs = future.get();
+        assertEquals(expectedJobs, actualJobs);
     }
 
     /**

--- a/walk-in-interview/src/test/java/com/google/job/data/JobsDatabaseTest.java
+++ b/walk-in-interview/src/test/java/com/google/job/data/JobsDatabaseTest.java
@@ -157,10 +157,10 @@ public final class JobsDatabaseTest {
         DocumentReference editedDocRef = editedDocRefFuture.get();
 
         // Asynchronously retrieve the document.
-        Future<DocumentSnapshot> documentSnapshoFuture = editedDocRef.get();
+        Future<DocumentSnapshot> documentSnapshotFuture = editedDocRef.get();
 
         // future.get() blocks on response.
-        DocumentSnapshot documentSnapshot = documentSnapshoFuture.get();
+        DocumentSnapshot documentSnapshot = documentSnapshotFuture.get();
 
         Job actualJob = documentSnapshot.toObject(Job.class);
 
@@ -269,15 +269,7 @@ public final class JobsDatabaseTest {
                 .setJobDuration(jobDuration)
                 .build();
 
-        Future<DocumentReference> addedJobFuture = firestore.collection("JobsForEligibilityTest").add(job1);
-
-        DocumentReference documentReference = addedJobFuture.get();
-        // Asynchronously retrieve the document.
-        ApiFuture<DocumentSnapshot> future = documentReference.get();
-
-        // future.get() blocks on response.
-        DocumentSnapshot document = future.get();
-        String jobId1 = document.getId();
+        firestore.collection("JobsForEligibilityTest").add(job1);
 
         requirements = Requirement.getLocalizedNames(Arrays.asList(O_LEVEL, ENGLISH), "en");
 
@@ -292,15 +284,7 @@ public final class JobsDatabaseTest {
             .setJobDuration(jobDuration)
             .build();
 
-        addedJobFuture = firestore.collection("JobsForEligibilityTest").add(job2);
-
-        documentReference = addedJobFuture.get();
-        // Asynchronously retrieve the document.
-        future = documentReference.get();
-
-        // future.get() blocks on response.
-        document = future.get();
-        String jobId2 = document.getId();
+        firestore.collection("JobsForEligibilityTest").add(job2);
 
         requirements = Requirement.getLocalizedNames(Arrays.asList(ENGLISH, DRIVING_LICENSE_C), "en");
 
@@ -345,15 +329,7 @@ public final class JobsDatabaseTest {
                 .setJobDuration(jobDuration)
                 .build();
 
-        addedJobFuture = firestore.collection("JobsForEligibilityTest").add(job5);
-
-        documentReference = addedJobFuture.get();
-        // Asynchronously retrieve the document.
-        future = documentReference.get();
-
-        // future.get() blocks on response.
-        document = future.get();
-        String jobId5 = document.getId();
+        firestore.collection("JobsForEligibilityTest").add(job5);
 
         List<String> skills = Requirement.getLocalizedNames(Arrays.asList(O_LEVEL, ENGLISH), "en");
 
@@ -361,9 +337,7 @@ public final class JobsDatabaseTest {
         Future<Collection<Job>> jobsFuture = jobsDatabase.fetchAllEligibleJobs(skills);
 
         // Assert.
-        Collection<Job> expectedJobs = new HashSet<>(Arrays.asList(job1.toBuilder().setJobId(jobId1).build(),
-                job2.toBuilder().setJobId(jobId2).build(),
-                job5.toBuilder().setJobId(jobId5).build()));
+        Collection<Job> expectedJobs = new HashSet<>(Arrays.asList(job1, job2, job5));
         Collection<Job> actualJobs = jobsFuture.get();
         assertEquals(expectedJobs, actualJobs);
     }

--- a/walk-in-interview/src/test/java/com/google/job/data/JobsDatabaseTest.java
+++ b/walk-in-interview/src/test/java/com/google/job/data/JobsDatabaseTest.java
@@ -1,6 +1,7 @@
 package com.google.job.data;
 
 import com.google.api.core.ApiFuture;
+import com.google.appengine.repackaged.com.google.common.collect.ImmutableMap;
 import com.google.cloud.firestore.*;
 import com.google.utils.FireStoreUtils;
 import org.junit.*;
@@ -55,8 +56,8 @@ public final class JobsDatabaseTest {
         Location expectedLocation =  new Location("Google", "123456", 0, 0);
         String expectedJobDescription = "Programming using java";
         JobPayment expectedJobPayment = new JobPayment(0, 5000, PaymentFrequency.MONTHLY);
-        List<String> expectedRequirements = Requirement.getRequirementIds(
-                Arrays.asList(DRIVING_LICENSE_C, O_LEVEL, ENGLISH));
+        Map<String, Boolean> expectedRequirements = ImmutableMap.of(DRIVING_LICENSE_C.getRequirementId(), true,
+                O_LEVEL.getRequirementId(), true, ENGLISH.getRequirementId(), true);
         long expectedPostExpiry = System.currentTimeMillis();
         JobDuration expectedJobDuration = JobDuration.SIX_MONTHS;
 
@@ -110,7 +111,8 @@ public final class JobsDatabaseTest {
         Location expectedLocation =  new Location("Google", "123456", 0, 0);
         String expectedJobDescription = "New employee";
         JobPayment expectedJobPayment = new JobPayment(0, 5000, PaymentFrequency.MONTHLY);
-        List<String> expectedRequirements = Requirement.getRequirementIds(Arrays.asList(O_LEVEL, ENGLISH));
+        Map<String, Boolean> expectedRequirements = ImmutableMap.of(DRIVING_LICENSE_C.getRequirementId(), false,
+                O_LEVEL.getRequirementId(), true, ENGLISH.getRequirementId(), true);
         long expectedPostExpiry = System.currentTimeMillis();
         JobDuration expectedJobDuration = JobDuration.ONE_MONTH;
 
@@ -209,7 +211,8 @@ public final class JobsDatabaseTest {
         Location expectedLocation =  new Location("Maple Tree", "123456", 0, 0);
         String expectedJobDescription = "Fighting to defeat hair line recede";
         JobPayment expectedJobPayment = new JobPayment(0, 5000, PaymentFrequency.MONTHLY);
-        List<String> expectedRequirements = Requirement.getRequirementIds(Arrays.asList(O_LEVEL));
+        Map<String, Boolean> expectedRequirements = ImmutableMap.of(DRIVING_LICENSE_C.getRequirementId(), false,
+                O_LEVEL.getRequirementId(), true, ENGLISH.getRequirementId(), false);
         long expectedPostExpiry = System.currentTimeMillis();;
         JobDuration expectedJobDuration = JobDuration.ONE_MONTH;
 
@@ -248,24 +251,24 @@ public final class JobsDatabaseTest {
     @Test
     public void fetchAllEligibleJobs_normalInput_success() throws IOException, ExecutionException, InterruptedException {
         // Arrange.
-        List<String> requirements = Requirement.getRequirementIds(Arrays.asList(O_LEVEL));
-
+        Map<String, Boolean> requirements = ImmutableMap.of(DRIVING_LICENSE_C.getRequirementId(), false,
+                O_LEVEL.getRequirementId(), true, ENGLISH.getRequirementId(), false);
         Job job1 = testJobDataCreation(JobStatus.ACTIVE, requirements);
 
-        requirements = Requirement.getRequirementIds(Arrays.asList(O_LEVEL, ENGLISH));
-
+        requirements = ImmutableMap.of(DRIVING_LICENSE_C.getRequirementId(), false,
+                O_LEVEL.getRequirementId(), true, ENGLISH.getRequirementId(), true);
         Job job2 = testJobDataCreation(JobStatus.ACTIVE, requirements);
 
-        requirements = Requirement.getRequirementIds(Arrays.asList(ENGLISH, DRIVING_LICENSE_C));
-
+        requirements = ImmutableMap.of(DRIVING_LICENSE_C.getRequirementId(), true,
+                O_LEVEL.getRequirementId(), false, ENGLISH.getRequirementId(), true);
         Job job3 = testJobDataCreation(JobStatus.ACTIVE, requirements);
 
-        requirements = Requirement.getRequirementIds(Arrays.asList(O_LEVEL, ENGLISH, DRIVING_LICENSE_C));
-
+        requirements = ImmutableMap.of(DRIVING_LICENSE_C.getRequirementId(), true,
+                O_LEVEL.getRequirementId(), true, ENGLISH.getRequirementId(), true);;
         Job job4 = testJobDataCreation(JobStatus.ACTIVE, requirements);
 
-        requirements = Requirement.getRequirementIds(Arrays.asList(ENGLISH));
-
+        requirements = ImmutableMap.of(DRIVING_LICENSE_C.getRequirementId(), false,
+                O_LEVEL.getRequirementId(), false, ENGLISH.getRequirementId(), true);;
         Job job5 = testJobDataCreation(JobStatus.ACTIVE, requirements);
 
         List<String> skills = Requirement.getRequirementIds(Arrays.asList(O_LEVEL, ENGLISH));
@@ -282,24 +285,24 @@ public final class JobsDatabaseTest {
     @Test
     public void fetchAllEligibleJobs_noJobMatch_noJobSelected() throws IOException, ExecutionException, InterruptedException {
         // Arrange.
-        List<String> requirements = Requirement.getRequirementIds(Arrays.asList(O_LEVEL));
-
+        Map<String, Boolean> requirements = ImmutableMap.of(DRIVING_LICENSE_C.getRequirementId(), false,
+                O_LEVEL.getRequirementId(), true, ENGLISH.getRequirementId(), false);
         Job job1 = testJobDataCreation(JobStatus.ACTIVE, requirements);
 
-        requirements = Requirement.getRequirementIds(Arrays.asList(O_LEVEL, ENGLISH));
-
+        requirements = ImmutableMap.of(DRIVING_LICENSE_C.getRequirementId(), false,
+                O_LEVEL.getRequirementId(), true, ENGLISH.getRequirementId(), true);
         Job job2 = testJobDataCreation(JobStatus.ACTIVE, requirements);
 
-        requirements = Requirement.getRequirementIds(Arrays.asList(ENGLISH, DRIVING_LICENSE_C));
-
+        requirements = ImmutableMap.of(DRIVING_LICENSE_C.getRequirementId(), true,
+                O_LEVEL.getRequirementId(), false, ENGLISH.getRequirementId(), true);
         Job job3 = testJobDataCreation(JobStatus.ACTIVE, requirements);
 
-        requirements = Requirement.getRequirementIds(Arrays.asList(O_LEVEL, ENGLISH, DRIVING_LICENSE_C));
-
+        requirements = ImmutableMap.of(DRIVING_LICENSE_C.getRequirementId(), true,
+                O_LEVEL.getRequirementId(), true, ENGLISH.getRequirementId(), true);;
         Job job4 = testJobDataCreation(JobStatus.ACTIVE, requirements);
 
-        requirements = Requirement.getRequirementIds(Arrays.asList(ENGLISH));
-
+        requirements = ImmutableMap.of(DRIVING_LICENSE_C.getRequirementId(), false,
+                O_LEVEL.getRequirementId(), false, ENGLISH.getRequirementId(), true);;
         Job job5 = testJobDataCreation(JobStatus.ACTIVE, requirements);
 
         List<String> skills = Requirement.getRequirementIds(Arrays.asList(DRIVING_LICENSE_C));
@@ -317,24 +320,24 @@ public final class JobsDatabaseTest {
     public void fetchAllEligibleJobs_hasDeletedJob_deletedJobNotSelected()
             throws IOException, ExecutionException, InterruptedException {
         // Arrange.
-        List<String> requirements = Requirement.getRequirementIds(Arrays.asList(O_LEVEL));
-
+        Map<String, Boolean> requirements = ImmutableMap.of(DRIVING_LICENSE_C.getRequirementId(), false,
+                O_LEVEL.getRequirementId(), true, ENGLISH.getRequirementId(), false);
         Job job1 = testJobDataCreation(JobStatus.ACTIVE, requirements);
 
-        requirements = Requirement.getRequirementIds(Arrays.asList(O_LEVEL, ENGLISH));
-
+        requirements = ImmutableMap.of(DRIVING_LICENSE_C.getRequirementId(), false,
+                O_LEVEL.getRequirementId(), true, ENGLISH.getRequirementId(), true);
         Job job2 = testJobDataCreation(JobStatus.DELETED, requirements);
 
-        requirements = Requirement.getRequirementIds(Arrays.asList(ENGLISH, DRIVING_LICENSE_C));
-
+        requirements = ImmutableMap.of(DRIVING_LICENSE_C.getRequirementId(), true,
+                O_LEVEL.getRequirementId(), false, ENGLISH.getRequirementId(), true);
         Job job3 = testJobDataCreation(JobStatus.ACTIVE, requirements);
 
-        requirements = Requirement.getRequirementIds(Arrays.asList(O_LEVEL, ENGLISH, DRIVING_LICENSE_C));
-
+        requirements = ImmutableMap.of(DRIVING_LICENSE_C.getRequirementId(), true,
+                O_LEVEL.getRequirementId(), true, ENGLISH.getRequirementId(), true);;
         Job job4 = testJobDataCreation(JobStatus.ACTIVE, requirements);
 
-        requirements = Requirement.getRequirementIds(Arrays.asList(ENGLISH));
-
+        requirements = ImmutableMap.of(DRIVING_LICENSE_C.getRequirementId(), false,
+                O_LEVEL.getRequirementId(), false, ENGLISH.getRequirementId(), true);;
         Job job5 = testJobDataCreation(JobStatus.ACTIVE, requirements);
 
         List<String> skills = Requirement.getRequirementIds(Arrays.asList(O_LEVEL, ENGLISH));
@@ -348,7 +351,7 @@ public final class JobsDatabaseTest {
         assertEquals(expectedJobs, actualJobs);
     }
 
-    private Job testJobDataCreation(JobStatus jobStatus, List<String> requirements)
+    private Job testJobDataCreation(JobStatus jobStatus, Map<String, Boolean> requirements)
             throws ExecutionException, InterruptedException {
         String jobName = "Programmer";
         Location location =  new Location("Maple Tree", "123456", 0, 0);

--- a/walk-in-interview/src/test/java/com/google/job/data/JobsDatabaseTest.java
+++ b/walk-in-interview/src/test/java/com/google/job/data/JobsDatabaseTest.java
@@ -269,7 +269,15 @@ public final class JobsDatabaseTest {
                 .setJobDuration(jobDuration)
                 .build();
 
-        firestore.collection("JobsForEligibilityTest").add(job1);
+        Future<DocumentReference> addedJobFuture = firestore.collection("JobsForEligibilityTest").add(job1);
+
+        DocumentReference documentReference = addedJobFuture.get();
+        // Asynchronously retrieve the document.
+        ApiFuture<DocumentSnapshot> future = documentReference.get();
+
+        // future.get() blocks on response.
+        DocumentSnapshot document = future.get();
+        String jobId1 = document.getId();
 
         requirements = Requirement.getLocalizedNames(Arrays.asList(O_LEVEL, ENGLISH), "en");
 
@@ -284,7 +292,15 @@ public final class JobsDatabaseTest {
             .setJobDuration(jobDuration)
             .build();
 
-        firestore.collection("JobsForEligibilityTest").add(job2);
+        addedJobFuture = firestore.collection("JobsForEligibilityTest").add(job2);
+
+        documentReference = addedJobFuture.get();
+        // Asynchronously retrieve the document.
+        future = documentReference.get();
+
+        // future.get() blocks on response.
+        document = future.get();
+        String jobId2 = document.getId();
 
         requirements = Requirement.getLocalizedNames(Arrays.asList(ENGLISH, DRIVING_LICENSE_C), "en");
 
@@ -329,16 +345,26 @@ public final class JobsDatabaseTest {
                 .setJobDuration(jobDuration)
                 .build();
 
-        firestore.collection("JobsForEligibilityTest").add(job5);
+        addedJobFuture = firestore.collection("JobsForEligibilityTest").add(job5);
+
+        documentReference = addedJobFuture.get();
+        // Asynchronously retrieve the document.
+        future = documentReference.get();
+
+        // future.get() blocks on response.
+        document = future.get();
+        String jobId5 = document.getId();
 
         List<String> skills = Requirement.getLocalizedNames(Arrays.asList(O_LEVEL, ENGLISH), "en");
 
         // Act.
-        Future<Collection<Job>> future = jobsDatabase.fetchAllEligibleJobs(skills);
+        Future<Collection<Job>> jobsFuture = jobsDatabase.fetchAllEligibleJobs(skills);
 
         // Assert.
-        Collection<Job> expectedJobs = Arrays.asList(job1, job2, job5);
-        Collection<Job> actualJobs = future.get();
+        Collection<Job> expectedJobs = new HashSet<>(Arrays.asList(job1.toBuilder().setJobId(jobId1).build(),
+                job2.toBuilder().setJobId(jobId2).build(),
+                job5.toBuilder().setJobId(jobId5).build()));
+        Collection<Job> actualJobs = jobsFuture.get();
         assertEquals(expectedJobs, actualJobs);
     }
 

--- a/walk-in-interview/src/test/java/com/google/job/data/JobsDatabaseTest.java
+++ b/walk-in-interview/src/test/java/com/google/job/data/JobsDatabaseTest.java
@@ -323,7 +323,7 @@ public final class JobsDatabaseTest {
 
         requirements = Requirement.getRequirementIds(Arrays.asList(O_LEVEL, ENGLISH));
 
-        Job job2 = testJobDataCreation(JobStatus.ACTIVE, requirements);
+        Job job2 = testJobDataCreation(JobStatus.DELETED, requirements);
 
         requirements = Requirement.getRequirementIds(Arrays.asList(ENGLISH, DRIVING_LICENSE_C));
 

--- a/walk-in-interview/src/test/java/com/google/job/data/JobsDatabaseTest.java
+++ b/walk-in-interview/src/test/java/com/google/job/data/JobsDatabaseTest.java
@@ -284,7 +284,7 @@ public final class JobsDatabaseTest {
             .setJobDuration(jobDuration)
             .build();
 
-        firestore.collection("JobsForEligibilityTest").add(job2);
+        firestore.collection(TEST_JOB_COLLECTION).add(job2);
 
         requirements = Requirement.getLocalizedNames(Arrays.asList(ENGLISH, DRIVING_LICENSE_C), "en");
 
@@ -329,7 +329,7 @@ public final class JobsDatabaseTest {
                 .setJobDuration(jobDuration)
                 .build();
 
-        firestore.collection(TEST_JOB_COLLECTION        ).add(job5);
+        firestore.collection(TEST_JOB_COLLECTION).add(job5);
 
         List<String> skills = Requirement.getLocalizedNames(Arrays.asList(O_LEVEL, ENGLISH), "en");
 

--- a/walk-in-interview/src/test/java/com/google/job/data/JobsDatabaseTest.java
+++ b/walk-in-interview/src/test/java/com/google/job/data/JobsDatabaseTest.java
@@ -342,6 +342,102 @@ public final class JobsDatabaseTest {
         assertEquals(expectedJobs, actualJobs);
     }
 
+    @Test
+    public void fetchAllEligibleJobs_noJobMatch_success() throws IOException, ExecutionException, InterruptedException {
+        // Arrange.
+        JobStatus jobStatus = JobStatus.ACTIVE;
+        String jobName = "Programmer";
+        Location location =  new Location("Maple Tree", "123456", 0, 0);
+        String jobDescription = "Fighting to defeat hair line recede";
+        JobPayment jobPayment = new JobPayment(0, 5000, PaymentFrequency.MONTHLY);
+        List<String> requirements = Requirement.getLocalizedNames(Arrays.asList(O_LEVEL), "en");
+        long postExpiry = System.currentTimeMillis();;
+        JobDuration jobDuration = JobDuration.ONE_MONTH;
+
+        Job job1 = Job.newBuilder()
+                .setJobStatus(jobStatus)
+                .setJobTitle(jobName)
+                .setLocation(location)
+                .setJobDescription(jobDescription)
+                .setJobPay(jobPayment)
+                .setRequirements(requirements)
+                .setPostExpiry(postExpiry)
+                .setJobDuration(jobDuration)
+                .build();
+
+        firestore.collection(TEST_JOB_COLLECTION).add(job1);
+
+        requirements = Requirement.getLocalizedNames(Arrays.asList(O_LEVEL, ENGLISH), "en");
+
+        Job job2 = Job.newBuilder()
+                .setJobStatus(jobStatus)
+                .setJobTitle(jobName)
+                .setLocation(location)
+                .setJobDescription(jobDescription)
+                .setJobPay(jobPayment)
+                .setRequirements(requirements)
+                .setPostExpiry(postExpiry)
+                .setJobDuration(jobDuration)
+                .build();
+
+        firestore.collection(TEST_JOB_COLLECTION).add(job2);
+
+        requirements = Requirement.getLocalizedNames(Arrays.asList(ENGLISH, DRIVING_LICENSE_C), "en");
+
+        Job job3 = Job.newBuilder()
+                .setJobStatus(jobStatus)
+                .setJobTitle(jobName)
+                .setLocation(location)
+                .setJobDescription(jobDescription)
+                .setJobPay(jobPayment)
+                .setRequirements(requirements)
+                .setPostExpiry(postExpiry)
+                .setJobDuration(jobDuration)
+                .build();
+
+        firestore.collection(TEST_JOB_COLLECTION).add(job3);
+
+        requirements = Requirement.getLocalizedNames(Arrays.asList(O_LEVEL, ENGLISH, DRIVING_LICENSE_C), "en");
+
+        Job job4 = Job.newBuilder()
+                .setJobStatus(jobStatus)
+                .setJobTitle(jobName)
+                .setLocation(location)
+                .setJobDescription(jobDescription)
+                .setJobPay(jobPayment)
+                .setRequirements(requirements)
+                .setPostExpiry(postExpiry)
+                .setJobDuration(jobDuration)
+                .build();
+
+        firestore.collection(TEST_JOB_COLLECTION).add(job4);
+
+        requirements = Requirement.getLocalizedNames(Arrays.asList(ENGLISH), "en");
+
+        Job job5 = Job.newBuilder()
+                .setJobStatus(jobStatus)
+                .setJobTitle(jobName)
+                .setLocation(location)
+                .setJobDescription(jobDescription)
+                .setJobPay(jobPayment)
+                .setRequirements(requirements)
+                .setPostExpiry(postExpiry)
+                .setJobDuration(jobDuration)
+                .build();
+
+        firestore.collection(TEST_JOB_COLLECTION).add(job5);
+
+        List<String> skills = Requirement.getLocalizedNames(Arrays.asList(DRIVING_LICENSE_C), "en");
+
+        // Act.
+        Future<Collection<Job>> jobsFuture = jobsDatabase.fetchAllEligibleJobs(skills);
+
+        // Assert.
+        Collection<Job> expectedJobs = new HashSet<>();
+        Collection<Job> actualJobs = jobsFuture.get();
+        assertEquals(expectedJobs, actualJobs);
+    }
+
     /**
      * Delete a collection in batches to avoid out-of-memory errors.
      *

--- a/walk-in-interview/src/test/java/com/google/job/data/JobsDatabaseTest.java
+++ b/walk-in-interview/src/test/java/com/google/job/data/JobsDatabaseTest.java
@@ -370,7 +370,8 @@ public final class JobsDatabaseTest {
                 .setJobDuration(jobDuration)
                 .build();
 
-        firestore.collection(TEST_JOB_COLLECTION).add(job1);
+        // future.get() blocks on response.
+        firestore.collection(TEST_JOB_COLLECTION).add(job1).get();
 
         requirements = Requirement.getLocalizedNames(Arrays.asList(O_LEVEL, ENGLISH), "en");
 
@@ -385,7 +386,8 @@ public final class JobsDatabaseTest {
                 .setJobDuration(jobDuration)
                 .build();
 
-        firestore.collection(TEST_JOB_COLLECTION).add(job2);
+        // future.get() blocks on response.
+        firestore.collection(TEST_JOB_COLLECTION).add(job2).get();
 
         requirements = Requirement.getLocalizedNames(Arrays.asList(ENGLISH, DRIVING_LICENSE_C), "en");
 
@@ -400,7 +402,8 @@ public final class JobsDatabaseTest {
                 .setJobDuration(jobDuration)
                 .build();
 
-        firestore.collection(TEST_JOB_COLLECTION).add(job3);
+        // future.get() blocks on response.
+        firestore.collection(TEST_JOB_COLLECTION).add(job3).get();
 
         requirements = Requirement.getLocalizedNames(Arrays.asList(O_LEVEL, ENGLISH, DRIVING_LICENSE_C), "en");
 
@@ -415,7 +418,8 @@ public final class JobsDatabaseTest {
                 .setJobDuration(jobDuration)
                 .build();
 
-        firestore.collection(TEST_JOB_COLLECTION).add(job4);
+        // future.get() blocks on response.
+        firestore.collection(TEST_JOB_COLLECTION).add(job4).get();
 
         requirements = Requirement.getLocalizedNames(Arrays.asList(ENGLISH), "en");
 
@@ -430,7 +434,8 @@ public final class JobsDatabaseTest {
                 .setJobDuration(jobDuration)
                 .build();
 
-        firestore.collection(TEST_JOB_COLLECTION).add(job5);
+        // future.get() blocks on response.
+        firestore.collection(TEST_JOB_COLLECTION).add(job5).get();
 
         List<String> skills = Requirement.getLocalizedNames(Arrays.asList(DRIVING_LICENSE_C), "en");
 

--- a/walk-in-interview/src/test/java/com/google/job/data/JobsDatabaseTest.java
+++ b/walk-in-interview/src/test/java/com/google/job/data/JobsDatabaseTest.java
@@ -55,7 +55,8 @@ public final class JobsDatabaseTest {
         Location expectedLocation =  new Location("Google", "123456", 0, 0);
         String expectedJobDescription = "Programming using java";
         JobPayment expectedJobPayment = new JobPayment(0, 5000, PaymentFrequency.MONTHLY);
-        List<Requirement> expectedRequirements = Arrays.asList(DRIVING_LICENSE_C, O_LEVEL, ENGLISH);
+        List<String> expectedRequirements = Requirement.getRequirementIds(
+                Arrays.asList(DRIVING_LICENSE_C, O_LEVEL, ENGLISH));
         long expectedPostExpiry = System.currentTimeMillis();
         JobDuration expectedJobDuration = JobDuration.SIX_MONTHS;
 
@@ -109,7 +110,7 @@ public final class JobsDatabaseTest {
         Location expectedLocation =  new Location("Google", "123456", 0, 0);
         String expectedJobDescription = "New employee";
         JobPayment expectedJobPayment = new JobPayment(0, 5000, PaymentFrequency.MONTHLY);
-        List<Requirement> expectedRequirements = Arrays.asList(O_LEVEL, ENGLISH);
+        List<String> expectedRequirements = Requirement.getRequirementIds(Arrays.asList(O_LEVEL, ENGLISH));
         long expectedPostExpiry = System.currentTimeMillis();
         JobDuration expectedJobDuration = JobDuration.ONE_MONTH;
 
@@ -208,7 +209,7 @@ public final class JobsDatabaseTest {
         Location expectedLocation =  new Location("Maple Tree", "123456", 0, 0);
         String expectedJobDescription = "Fighting to defeat hair line recede";
         JobPayment expectedJobPayment = new JobPayment(0, 5000, PaymentFrequency.MONTHLY);
-        List<Requirement> expectedRequirements = Arrays.asList(O_LEVEL);
+        List<String> expectedRequirements = Requirement.getRequirementIds(Arrays.asList(O_LEVEL));
         long expectedPostExpiry = System.currentTimeMillis();;
         JobDuration expectedJobDuration = JobDuration.ONE_MONTH;
 
@@ -247,27 +248,27 @@ public final class JobsDatabaseTest {
     @Test
     public void fetchAllEligibleJobs_normalInput_success() throws IOException, ExecutionException, InterruptedException {
         // Arrange.
-        List<Requirement> requirements = Arrays.asList(O_LEVEL);
+        List<String> requirements = Requirement.getRequirementIds(Arrays.asList(O_LEVEL));
 
         Job job1 = testJobDataCreation(JobStatus.ACTIVE, requirements);
 
-        requirements = Arrays.asList(O_LEVEL, ENGLISH);
+        requirements = Requirement.getRequirementIds(Arrays.asList(O_LEVEL, ENGLISH));
 
         Job job2 = testJobDataCreation(JobStatus.ACTIVE, requirements);
 
-        requirements = Arrays.asList(ENGLISH, DRIVING_LICENSE_C);
+        requirements = Requirement.getRequirementIds(Arrays.asList(ENGLISH, DRIVING_LICENSE_C));
 
         Job job3 = testJobDataCreation(JobStatus.ACTIVE, requirements);
 
-        requirements = Arrays.asList(O_LEVEL, ENGLISH, DRIVING_LICENSE_C);
+        requirements = Requirement.getRequirementIds(Arrays.asList(O_LEVEL, ENGLISH, DRIVING_LICENSE_C));
 
         Job job4 = testJobDataCreation(JobStatus.ACTIVE, requirements);
 
-        requirements = Arrays.asList(ENGLISH);
+        requirements = Requirement.getRequirementIds(Arrays.asList(ENGLISH));
 
         Job job5 = testJobDataCreation(JobStatus.ACTIVE, requirements);
 
-        List<Requirement> skills = Arrays.asList(O_LEVEL, ENGLISH);
+        List<String> skills = Requirement.getRequirementIds(Arrays.asList(O_LEVEL, ENGLISH));
 
         // Act.
         Future<Collection<Job>> jobsFuture = jobsDatabase.fetchAllEligibleJobs(skills);
@@ -281,27 +282,27 @@ public final class JobsDatabaseTest {
     @Test
     public void fetchAllEligibleJobs_noJobMatch_noJobSelected() throws IOException, ExecutionException, InterruptedException {
         // Arrange.
-        List<Requirement> requirements = Arrays.asList(O_LEVEL);
+        List<String> requirements = Requirement.getRequirementIds(Arrays.asList(O_LEVEL));
 
         Job job1 = testJobDataCreation(JobStatus.ACTIVE, requirements);
 
-        requirements = Arrays.asList(O_LEVEL, ENGLISH);
+        requirements = Requirement.getRequirementIds(Arrays.asList(O_LEVEL, ENGLISH));
 
         Job job2 = testJobDataCreation(JobStatus.ACTIVE, requirements);
 
-        requirements = Arrays.asList(ENGLISH, DRIVING_LICENSE_C);
+        requirements = Requirement.getRequirementIds(Arrays.asList(ENGLISH, DRIVING_LICENSE_C));
 
         Job job3 = testJobDataCreation(JobStatus.ACTIVE, requirements);
 
-        requirements = Arrays.asList(O_LEVEL, ENGLISH, DRIVING_LICENSE_C);
+        requirements = Requirement.getRequirementIds(Arrays.asList(O_LEVEL, ENGLISH, DRIVING_LICENSE_C));
 
         Job job4 = testJobDataCreation(JobStatus.ACTIVE, requirements);
 
-        requirements = Arrays.asList(ENGLISH);
+        requirements = Requirement.getRequirementIds(Arrays.asList(ENGLISH));
 
         Job job5 = testJobDataCreation(JobStatus.ACTIVE, requirements);
 
-        List<Requirement> skills = Arrays.asList(DRIVING_LICENSE_C);
+        List<String> skills = Requirement.getRequirementIds(Arrays.asList(DRIVING_LICENSE_C));
 
         // Act.
         Future<Collection<Job>> jobsFuture = jobsDatabase.fetchAllEligibleJobs(skills);
@@ -316,27 +317,27 @@ public final class JobsDatabaseTest {
     public void fetchAllEligibleJobs_hasDeletedJob_deletedJobNotSelected()
             throws IOException, ExecutionException, InterruptedException {
         // Arrange.
-        List<Requirement> requirements = Arrays.asList(O_LEVEL);
+        List<String> requirements = Requirement.getRequirementIds(Arrays.asList(O_LEVEL));
 
         Job job1 = testJobDataCreation(JobStatus.ACTIVE, requirements);
 
-        requirements = Arrays.asList(O_LEVEL, ENGLISH);
+        requirements = Requirement.getRequirementIds(Arrays.asList(O_LEVEL, ENGLISH));
 
-        Job job2 = testJobDataCreation(JobStatus.DELETED, requirements);
+        Job job2 = testJobDataCreation(JobStatus.ACTIVE, requirements);
 
-        requirements = Arrays.asList(ENGLISH, DRIVING_LICENSE_C);
+        requirements = Requirement.getRequirementIds(Arrays.asList(ENGLISH, DRIVING_LICENSE_C));
 
         Job job3 = testJobDataCreation(JobStatus.ACTIVE, requirements);
 
-        requirements = Arrays.asList(O_LEVEL, ENGLISH, DRIVING_LICENSE_C);
+        requirements = Requirement.getRequirementIds(Arrays.asList(O_LEVEL, ENGLISH, DRIVING_LICENSE_C));
 
         Job job4 = testJobDataCreation(JobStatus.ACTIVE, requirements);
 
-        requirements = Arrays.asList(ENGLISH);
+        requirements = Requirement.getRequirementIds(Arrays.asList(ENGLISH));
 
         Job job5 = testJobDataCreation(JobStatus.ACTIVE, requirements);
 
-        List<Requirement> skills = Arrays.asList(O_LEVEL, ENGLISH);
+        List<String> skills = Requirement.getRequirementIds(Arrays.asList(O_LEVEL, ENGLISH));
 
         // Act.
         Future<Collection<Job>> jobsFuture = jobsDatabase.fetchAllEligibleJobs(skills);
@@ -347,7 +348,7 @@ public final class JobsDatabaseTest {
         assertEquals(expectedJobs, actualJobs);
     }
 
-    private Job testJobDataCreation(JobStatus jobStatus, List<Requirement> requirements)
+    private Job testJobDataCreation(JobStatus jobStatus, List<String> requirements)
             throws ExecutionException, InterruptedException {
         String jobName = "Programmer";
         Location location =  new Location("Maple Tree", "123456", 0, 0);

--- a/walk-in-interview/src/test/java/com/google/job/data/JobsDatabaseTest.java
+++ b/walk-in-interview/src/test/java/com/google/job/data/JobsDatabaseTest.java
@@ -249,92 +249,25 @@ public final class JobsDatabaseTest {
     @Test
     public void fetchAllEligibleJobs_normalInput_success() throws IOException, ExecutionException, InterruptedException {
         // Arrange.
-        JobStatus jobStatus = JobStatus.ACTIVE;
-        String jobName = "Programmer";
-        Location location =  new Location("Maple Tree", "123456", 0, 0);
-        String jobDescription = "Fighting to defeat hair line recede";
-        JobPayment jobPayment = new JobPayment(0, 5000, PaymentFrequency.MONTHLY);
         List<String> requirements = Requirement.getLocalizedNames(Arrays.asList(O_LEVEL), "en");
-        long postExpiry = System.currentTimeMillis();;
-        JobDuration jobDuration = JobDuration.ONE_MONTH;
 
-        Job job1 = Job.newBuilder()
-                .setJobStatus(jobStatus)
-                .setJobTitle(jobName)
-                .setLocation(location)
-                .setJobDescription(jobDescription)
-                .setJobPay(jobPayment)
-                .setRequirements(requirements)
-                .setPostExpiry(postExpiry)
-                .setJobDuration(jobDuration)
-                .build();
-
-        // future.get() blocks on response.
-        firestore.collection(TEST_JOB_COLLECTION).add(job1).get();
+        Job job1 = testJobDataCreation(JobStatus.ACTIVE, requirements);
 
         requirements = Requirement.getLocalizedNames(Arrays.asList(O_LEVEL, ENGLISH), "en");
 
-        Job job2 = Job.newBuilder()
-            .setJobStatus(jobStatus)
-            .setJobTitle(jobName)
-            .setLocation(location)
-            .setJobDescription(jobDescription)
-            .setJobPay(jobPayment)
-            .setRequirements(requirements)
-            .setPostExpiry(postExpiry)
-            .setJobDuration(jobDuration)
-            .build();
-
-        // future.get() blocks on response.
-        firestore.collection(TEST_JOB_COLLECTION).add(job2).get();
+        Job job2 = testJobDataCreation(JobStatus.ACTIVE, requirements);
 
         requirements = Requirement.getLocalizedNames(Arrays.asList(ENGLISH, DRIVING_LICENSE_C), "en");
 
-        Job job3 = Job.newBuilder()
-                .setJobStatus(jobStatus)
-                .setJobTitle(jobName)
-                .setLocation(location)
-                .setJobDescription(jobDescription)
-                .setJobPay(jobPayment)
-                .setRequirements(requirements)
-                .setPostExpiry(postExpiry)
-                .setJobDuration(jobDuration)
-                .build();
-
-        // future.get() blocks on response.
-        firestore.collection(TEST_JOB_COLLECTION).add(job3).get();
+        Job job3 = testJobDataCreation(JobStatus.ACTIVE, requirements);
 
         requirements = Requirement.getLocalizedNames(Arrays.asList(O_LEVEL, ENGLISH, DRIVING_LICENSE_C), "en");
 
-        Job job4 = Job.newBuilder()
-                .setJobStatus(jobStatus)
-                .setJobTitle(jobName)
-                .setLocation(location)
-                .setJobDescription(jobDescription)
-                .setJobPay(jobPayment)
-                .setRequirements(requirements)
-                .setPostExpiry(postExpiry)
-                .setJobDuration(jobDuration)
-                .build();
-
-        // future.get() blocks on response.
-        firestore.collection(TEST_JOB_COLLECTION).add(job4).get();
+        Job job4 = testJobDataCreation(JobStatus.ACTIVE, requirements);
 
         requirements = Requirement.getLocalizedNames(Arrays.asList(ENGLISH), "en");
 
-        Job job5 = Job.newBuilder()
-                .setJobStatus(jobStatus)
-                .setJobTitle(jobName)
-                .setLocation(location)
-                .setJobDescription(jobDescription)
-                .setJobPay(jobPayment)
-                .setRequirements(requirements)
-                .setPostExpiry(postExpiry)
-                .setJobDuration(jobDuration)
-                .build();
-
-        // future.get() blocks on response.
-        firestore.collection(TEST_JOB_COLLECTION).add(job5).get();
+        Job job5 = testJobDataCreation(JobStatus.ACTIVE, requirements);
 
         List<String> skills = Requirement.getLocalizedNames(Arrays.asList(O_LEVEL, ENGLISH), "en");
 
@@ -350,92 +283,25 @@ public final class JobsDatabaseTest {
     @Test
     public void fetchAllEligibleJobs_noJobMatch_noJobSelected() throws IOException, ExecutionException, InterruptedException {
         // Arrange.
-        JobStatus jobStatus = JobStatus.ACTIVE;
-        String jobName = "Programmer";
-        Location location =  new Location("Maple Tree", "123456", 0, 0);
-        String jobDescription = "Fighting to defeat hair line recede";
-        JobPayment jobPayment = new JobPayment(0, 5000, PaymentFrequency.MONTHLY);
         List<String> requirements = Requirement.getLocalizedNames(Arrays.asList(O_LEVEL), "en");
-        long postExpiry = System.currentTimeMillis();;
-        JobDuration jobDuration = JobDuration.ONE_MONTH;
 
-        Job job1 = Job.newBuilder()
-                .setJobStatus(jobStatus)
-                .setJobTitle(jobName)
-                .setLocation(location)
-                .setJobDescription(jobDescription)
-                .setJobPay(jobPayment)
-                .setRequirements(requirements)
-                .setPostExpiry(postExpiry)
-                .setJobDuration(jobDuration)
-                .build();
-
-        // future.get() blocks on response.
-        firestore.collection(TEST_JOB_COLLECTION).add(job1).get();
+        Job job1 = testJobDataCreation(JobStatus.ACTIVE, requirements);
 
         requirements = Requirement.getLocalizedNames(Arrays.asList(O_LEVEL, ENGLISH), "en");
 
-        Job job2 = Job.newBuilder()
-                .setJobStatus(jobStatus)
-                .setJobTitle(jobName)
-                .setLocation(location)
-                .setJobDescription(jobDescription)
-                .setJobPay(jobPayment)
-                .setRequirements(requirements)
-                .setPostExpiry(postExpiry)
-                .setJobDuration(jobDuration)
-                .build();
-
-        // future.get() blocks on response.
-        firestore.collection(TEST_JOB_COLLECTION).add(job2).get();
+        Job job2 = testJobDataCreation(JobStatus.ACTIVE, requirements);
 
         requirements = Requirement.getLocalizedNames(Arrays.asList(ENGLISH, DRIVING_LICENSE_C), "en");
 
-        Job job3 = Job.newBuilder()
-                .setJobStatus(jobStatus)
-                .setJobTitle(jobName)
-                .setLocation(location)
-                .setJobDescription(jobDescription)
-                .setJobPay(jobPayment)
-                .setRequirements(requirements)
-                .setPostExpiry(postExpiry)
-                .setJobDuration(jobDuration)
-                .build();
-
-        // future.get() blocks on response.
-        firestore.collection(TEST_JOB_COLLECTION).add(job3).get();
+        Job job3 = testJobDataCreation(JobStatus.ACTIVE, requirements);
 
         requirements = Requirement.getLocalizedNames(Arrays.asList(O_LEVEL, ENGLISH, DRIVING_LICENSE_C), "en");
 
-        Job job4 = Job.newBuilder()
-                .setJobStatus(jobStatus)
-                .setJobTitle(jobName)
-                .setLocation(location)
-                .setJobDescription(jobDescription)
-                .setJobPay(jobPayment)
-                .setRequirements(requirements)
-                .setPostExpiry(postExpiry)
-                .setJobDuration(jobDuration)
-                .build();
-
-        // future.get() blocks on response.
-        firestore.collection(TEST_JOB_COLLECTION).add(job4).get();
+        Job job4 = testJobDataCreation(JobStatus.ACTIVE, requirements);
 
         requirements = Requirement.getLocalizedNames(Arrays.asList(ENGLISH), "en");
 
-        Job job5 = Job.newBuilder()
-                .setJobStatus(jobStatus)
-                .setJobTitle(jobName)
-                .setLocation(location)
-                .setJobDescription(jobDescription)
-                .setJobPay(jobPayment)
-                .setRequirements(requirements)
-                .setPostExpiry(postExpiry)
-                .setJobDuration(jobDuration)
-                .build();
-
-        // future.get() blocks on response.
-        firestore.collection(TEST_JOB_COLLECTION).add(job5).get();
+        Job job5 = testJobDataCreation(JobStatus.ACTIVE, requirements);
 
         List<String> skills = Requirement.getLocalizedNames(Arrays.asList(DRIVING_LICENSE_C), "en");
 
@@ -452,92 +318,25 @@ public final class JobsDatabaseTest {
     public void fetchAllEligibleJobs_hasDeletedJob_deletedJobNotSelected()
             throws IOException, ExecutionException, InterruptedException {
         // Arrange.
-        JobStatus jobStatus = JobStatus.ACTIVE;
-        String jobName = "Programmer";
-        Location location =  new Location("Maple Tree", "123456", 0, 0);
-        String jobDescription = "Fighting to defeat hair line recede";
-        JobPayment jobPayment = new JobPayment(0, 5000, PaymentFrequency.MONTHLY);
         List<String> requirements = Requirement.getLocalizedNames(Arrays.asList(O_LEVEL), "en");
-        long postExpiry = System.currentTimeMillis();;
-        JobDuration jobDuration = JobDuration.ONE_MONTH;
 
-        Job job1 = Job.newBuilder()
-                .setJobStatus(jobStatus)
-                .setJobTitle(jobName)
-                .setLocation(location)
-                .setJobDescription(jobDescription)
-                .setJobPay(jobPayment)
-                .setRequirements(requirements)
-                .setPostExpiry(postExpiry)
-                .setJobDuration(jobDuration)
-                .build();
-
-        // future.get() blocks on response.
-        firestore.collection(TEST_JOB_COLLECTION).add(job1).get();
+        Job job1 = testJobDataCreation(JobStatus.ACTIVE, requirements);
 
         requirements = Requirement.getLocalizedNames(Arrays.asList(O_LEVEL, ENGLISH), "en");
 
-        Job job2 = Job.newBuilder()
-                .setJobStatus(JobStatus.DELETED)
-                .setJobTitle(jobName)
-                .setLocation(location)
-                .setJobDescription(jobDescription)
-                .setJobPay(jobPayment)
-                .setRequirements(requirements)
-                .setPostExpiry(postExpiry)
-                .setJobDuration(jobDuration)
-                .build();
-
-        // future.get() blocks on response.
-        firestore.collection(TEST_JOB_COLLECTION).add(job2).get();
+        Job job2 = testJobDataCreation(JobStatus.DELETED, requirements);
 
         requirements = Requirement.getLocalizedNames(Arrays.asList(ENGLISH, DRIVING_LICENSE_C), "en");
 
-        Job job3 = Job.newBuilder()
-                .setJobStatus(jobStatus)
-                .setJobTitle(jobName)
-                .setLocation(location)
-                .setJobDescription(jobDescription)
-                .setJobPay(jobPayment)
-                .setRequirements(requirements)
-                .setPostExpiry(postExpiry)
-                .setJobDuration(jobDuration)
-                .build();
-
-        // future.get() blocks on response.
-        firestore.collection(TEST_JOB_COLLECTION).add(job3).get();
+        Job job3 = testJobDataCreation(JobStatus.ACTIVE, requirements);
 
         requirements = Requirement.getLocalizedNames(Arrays.asList(O_LEVEL, ENGLISH, DRIVING_LICENSE_C), "en");
 
-        Job job4 = Job.newBuilder()
-                .setJobStatus(jobStatus)
-                .setJobTitle(jobName)
-                .setLocation(location)
-                .setJobDescription(jobDescription)
-                .setJobPay(jobPayment)
-                .setRequirements(requirements)
-                .setPostExpiry(postExpiry)
-                .setJobDuration(jobDuration)
-                .build();
-
-        // future.get() blocks on response.
-        firestore.collection(TEST_JOB_COLLECTION).add(job4).get();
+        Job job4 = testJobDataCreation(JobStatus.ACTIVE, requirements);
 
         requirements = Requirement.getLocalizedNames(Arrays.asList(ENGLISH), "en");
 
-        Job job5 = Job.newBuilder()
-                .setJobStatus(jobStatus)
-                .setJobTitle(jobName)
-                .setLocation(location)
-                .setJobDescription(jobDescription)
-                .setJobPay(jobPayment)
-                .setRequirements(requirements)
-                .setPostExpiry(postExpiry)
-                .setJobDuration(jobDuration)
-                .build();
-
-        // future.get() blocks on response.
-        firestore.collection(TEST_JOB_COLLECTION).add(job5).get();
+        Job job5 = testJobDataCreation(JobStatus.ACTIVE, requirements);
 
         List<String> skills = Requirement.getLocalizedNames(Arrays.asList(O_LEVEL, ENGLISH), "en");
 
@@ -548,6 +347,32 @@ public final class JobsDatabaseTest {
         Collection<Job> expectedJobs = new HashSet<>(Arrays.asList(job1, job5));
         Collection<Job> actualJobs = jobsFuture.get();
         assertEquals(expectedJobs, actualJobs);
+    }
+
+    private Job testJobDataCreation(JobStatus jobStatus, List<String> requirements)
+            throws ExecutionException, InterruptedException {
+        String jobName = "Programmer";
+        Location location =  new Location("Maple Tree", "123456", 0, 0);
+        String jobDescription = "Fighting to defeat hair line recede";
+        JobPayment jobPayment = new JobPayment(0, 5000, PaymentFrequency.MONTHLY);
+        long postExpiry = System.currentTimeMillis();;
+        JobDuration jobDuration = JobDuration.ONE_MONTH;
+
+        Job job = Job.newBuilder()
+                .setJobStatus(jobStatus)
+                .setJobTitle(jobName)
+                .setLocation(location)
+                .setJobDescription(jobDescription)
+                .setJobPay(jobPayment)
+                .setRequirements(requirements)
+                .setPostExpiry(postExpiry)
+                .setJobDuration(jobDuration)
+                .build();
+
+        // future.get() blocks on response.
+        firestore.collection(TEST_JOB_COLLECTION).add(job).get();
+
+        return job;
     }
 
     /**

--- a/walk-in-interview/src/test/java/com/google/job/data/JobsDatabaseTest.java
+++ b/walk-in-interview/src/test/java/com/google/job/data/JobsDatabaseTest.java
@@ -269,7 +269,8 @@ public final class JobsDatabaseTest {
                 .setJobDuration(jobDuration)
                 .build();
 
-        firestore.collection(TEST_JOB_COLLECTION).add(job1);
+        // future.get() blocks on response.
+        firestore.collection(TEST_JOB_COLLECTION).add(job1).get();
 
         requirements = Requirement.getLocalizedNames(Arrays.asList(O_LEVEL, ENGLISH), "en");
 
@@ -284,7 +285,8 @@ public final class JobsDatabaseTest {
             .setJobDuration(jobDuration)
             .build();
 
-        firestore.collection(TEST_JOB_COLLECTION).add(job2);
+        // future.get() blocks on response.
+        firestore.collection(TEST_JOB_COLLECTION).add(job2).get();
 
         requirements = Requirement.getLocalizedNames(Arrays.asList(ENGLISH, DRIVING_LICENSE_C), "en");
 
@@ -299,7 +301,8 @@ public final class JobsDatabaseTest {
                 .setJobDuration(jobDuration)
                 .build();
 
-        firestore.collection(TEST_JOB_COLLECTION).add(job3);
+        // future.get() blocks on response.
+        firestore.collection(TEST_JOB_COLLECTION).add(job3).get();
 
         requirements = Requirement.getLocalizedNames(Arrays.asList(O_LEVEL, ENGLISH, DRIVING_LICENSE_C), "en");
 
@@ -314,7 +317,8 @@ public final class JobsDatabaseTest {
                 .setJobDuration(jobDuration)
                 .build();
 
-        firestore.collection(TEST_JOB_COLLECTION).add(job4);
+        // future.get() blocks on response.
+        firestore.collection(TEST_JOB_COLLECTION).add(job4).get();
 
         requirements = Requirement.getLocalizedNames(Arrays.asList(ENGLISH), "en");
 
@@ -329,7 +333,8 @@ public final class JobsDatabaseTest {
                 .setJobDuration(jobDuration)
                 .build();
 
-        firestore.collection(TEST_JOB_COLLECTION).add(job5);
+        // future.get() blocks on response.
+        firestore.collection(TEST_JOB_COLLECTION).add(job5).get();
 
         List<String> skills = Requirement.getLocalizedNames(Arrays.asList(O_LEVEL, ENGLISH), "en");
 

--- a/walk-in-interview/src/test/webapp/update-job/script_test.js
+++ b/walk-in-interview/src/test/webapp/update-job/script_test.js
@@ -444,12 +444,6 @@ describe('Update Job Tests', function() {
       // Since all fields should be pre-filled with existing job post,
       // there is no need to add valid inputs to all fields again.
 
-      it('no error message for all valid inputs', () => {
-        return clickUpdate(driver)
-            .then(() => driver.findElement(By.id('error-message')).getText())
-            .then((text) => assert.equal(text, ''));
-      });
-
       it('no job title', () => {
         /**
          * The job title must be cleared here to test it.

--- a/walk-in-interview/src/test/webapp/update-job/script_test.js
+++ b/walk-in-interview/src/test/webapp/update-job/script_test.js
@@ -226,22 +226,28 @@ describe('Update Job Tests', function() {
         return driver.findElements(By.name('requirement'))
             .then((requirements) => {
               requirements.map((requirement) => {
-                if (requirement.getText() === 'O Level') {
-                  requirement.getAttribute('checked')
-                  .then((checked) => {
-                    assert.isTrue(checked);
-                  });
-                } else if (requirement.getText() === 'English') {
-                  requirement.getAttribute('checked')
-                  .then((checked) => {
-                    assert.isTrue(checked);
-                  });
-                } else {
-                  requirement.getAttribute('checked')
-                  .then((checked) => {
-                    assert.isNotTrue(checked);
-                  });
-                }
+                requirement.getText()
+                .then((text) => {
+                  if (text === 'O Level' || text === 'English') {
+                    const id = getKeyByValue(REQUIREMENTS_LIST, text);
+                    driver.findElement(By.id(id))
+                    .then((requirement) => {
+                      requirement.getAttribute('checked')
+                      .then((checked) => {
+                        assert.isTrue(checked);
+                      });
+                    });
+                  } else {
+                    const id = getKeyByValue(REQUIREMENTS_LIST, text);
+                    driver.findElement(By.id(id))
+                    .then((requirement) => {
+                      requirement.getAttribute('checked')
+                      .then((checked) => {
+                        assert.isNotTrue(checked);
+                      });
+                    });
+                  }
+                });
               });
             });
       });
@@ -525,3 +531,13 @@ function clickUpdate(driver) {
 function clickCancel(driver) {
   return driver.findElement(By.id('cancel')).click();
 };
+
+/**
+ * Gets the corresponding key according to its value.
+ * 
+ * @param {*} map Target map.
+ * @param {*} value Value.
+ */
+function getKeyByValue(map, value) {
+  return Object.keys(map).find(key => map[key] === value);
+}

--- a/walk-in-interview/src/test/webapp/update-job/script_test.js
+++ b/walk-in-interview/src/test/webapp/update-job/script_test.js
@@ -442,9 +442,6 @@ describe('Update Job Tests', function() {
      * message with the invalid field, and no POST request will be made.
      */
     describe('Submit Button', () => {
-      const date = new Date();
-      const today = `${(date.getMonth() + 1)}-${date.getDate()}` +
-        `-${date.getFullYear()}`;
 
       // Since all fields should be pre-filled with existing job post,
       // there is no need to add valid inputs to all fields again.

--- a/walk-in-interview/src/test/webapp/update-job/script_test.js
+++ b/walk-in-interview/src/test/webapp/update-job/script_test.js
@@ -226,10 +226,9 @@ describe('Update Job Tests', function() {
         return driver.findElements(By.name('requirement'))
             .then((requirements) => {
               requirements.map((requirement) => {
-                requirement.getText()
-                .then((text) => {
-                  if (text === 'O Level' || text === 'English') {
-                    const id = getKeyByValue(REQUIREMENTS_LIST, text);
+                requirement.getAttribute('id')
+                .then((id) => {
+                  if (id === 'O Level' || id === 'English') {
                     driver.findElement(By.id(id))
                     .then((requirement) => {
                       requirement.getAttribute('checked')
@@ -238,7 +237,6 @@ describe('Update Job Tests', function() {
                       });
                     });
                   } else {
-                    const id = getKeyByValue(REQUIREMENTS_LIST, text);
                     driver.findElement(By.id(id))
                     .then((requirement) => {
                       requirement.getAttribute('checked')
@@ -531,13 +529,3 @@ function clickUpdate(driver) {
 function clickCancel(driver) {
   return driver.findElement(By.id('cancel')).click();
 };
-
-/**
- * Gets the corresponding key according to its value.
- * 
- * @param {*} map Target map.
- * @param {*} value Value.
- */
-function getKeyByValue(map, value) {
-  return Object.keys(map).find(key => map[key] === value);
-}

--- a/walk-in-interview/src/test/webapp/update-job/script_test.js
+++ b/walk-in-interview/src/test/webapp/update-job/script_test.js
@@ -222,7 +222,7 @@ describe('Update Job Tests', function() {
             });
       });
 
-      it('checks the default option properly ticked', () => {
+      it('checks only the default options properly ticked', () => {
         return driver.findElements(By.name('requirement'))
             .then((requirements) => {
               requirements.map((requirement) => {

--- a/walk-in-interview/src/test/webapp/update-job/script_test.js
+++ b/walk-in-interview/src/test/webapp/update-job/script_test.js
@@ -223,28 +223,25 @@ describe('Update Job Tests', function() {
       });
 
       it('checks the default option properly ticked', () => {
-        return driver.findElements(By.className('requirement'))
+        return driver.findElements(By.name('requirement'))
             .then((requirements) => {
               requirements.map((requirement) => {
-                requirement.getText()
-                .then((requirement, text) => {
-                  if (text === 'O Level') {
-                    requirement.getAttribute('checked')
-                    .then((checked) => {
-                      assert.isTrue(checked);
-                    });
-                  } else if (text === 'English') {
-                    requirement.getAttribute('checked')
-                    .then((checked) => {
-                      assert.isTrue(checked);
-                    });
-                  } else {
-                    requirement.getAttribute('checked')
-                    .then((checked) => {
-                      assert.isNotTrue(checked);
-                    });
-                  }
-                });
+                if (requirement.getText() === 'O Level') {
+                  requirement.getAttribute('checked')
+                  .then((checked) => {
+                    assert.isTrue(checked);
+                  });
+                } else if (requirement.getText() === 'English') {
+                  requirement.getAttribute('checked')
+                  .then((checked) => {
+                    assert.isTrue(checked);
+                  });
+                } else {
+                  requirement.getAttribute('checked')
+                  .then((checked) => {
+                    assert.isNotTrue(checked);
+                  });
+                }
               });
             });
       });

--- a/walk-in-interview/src/test/webapp/update-job/script_test.js
+++ b/walk-in-interview/src/test/webapp/update-job/script_test.js
@@ -208,7 +208,7 @@ describe('Update Job Tests', function() {
       });
 
       it('checks correct requirement list rendered', () => {
-        return driver.findElement(By.id('requirement'))
+        return driver.findElement(By.id('requirements-list'))
             .getText()
             .then((text) => {
               const list = REQUIREMENTS_LIST;
@@ -223,7 +223,7 @@ describe('Update Job Tests', function() {
       });
 
       it('checks the default option properly ticked', () => {
-        return driver.findElements(By.id('requirement'))
+        return driver.findElements(By.className('requirement'))
             .then((requirements) => {
               requirements.map((requirement) => {
                 requirement.getText()

--- a/walk-in-interview/src/test/webapp/update-job/script_test.js
+++ b/walk-in-interview/src/test/webapp/update-job/script_test.js
@@ -223,24 +223,29 @@ describe('Update Job Tests', function() {
       });
 
       it('checks the default option properly ticked', () => {
-        return driver.findElement(By.id('requirements-list'))
-            .getText()
-            .then((text) => {
-              for (const requirement in text) {
-                if (requirement === 'O Level') {
-                  requirement.getAttribute('checked')
-                  .then((checked) => {
-                    assert.isTrue(checked);
-                  })
-                }
-
-                if (requirement === 'English') {
-                  requirement.getAttribute('checked')
-                  .then((checked) => {
-                    assert.isTrue(checked);
-                  })
-                }
-              }
+        return driver.findElements(By.className('requirement'))
+            .then((requirements) => {
+              requirements.map((requirement) => {
+                requirement.getText()
+                .then((requirement, text) => {
+                  if (text === 'O Level') {
+                    requirement.getAttribute('checked')
+                    .then((checked) => {
+                      assert.isTrue(checked);
+                    });
+                  } else if (text === 'English') {
+                    requirement.getAttribute('checked')
+                    .then((checked) => {
+                      assert.isTrue(checked);
+                    });
+                  } else {
+                    requirement.getAttribute('checked')
+                    .then((checked) => {
+                      assert.isNotTrue(checked);
+                    });
+                  }
+                });
+              });
             });
       });
     });

--- a/walk-in-interview/src/test/webapp/update-job/script_test.js
+++ b/walk-in-interview/src/test/webapp/update-job/script_test.js
@@ -208,7 +208,7 @@ describe('Update Job Tests', function() {
       });
 
       it('checks correct requirement list rendered', () => {
-        return driver.findElement(By.id('requirements-list'))
+        return driver.findElement(By.id('requirement'))
             .getText()
             .then((text) => {
               const list = REQUIREMENTS_LIST;
@@ -223,7 +223,7 @@ describe('Update Job Tests', function() {
       });
 
       it('checks the default option properly ticked', () => {
-        return driver.findElements(By.className('requirement'))
+        return driver.findElements(By.id('requirement'))
             .then((requirements) => {
               requirements.map((requirement) => {
                 requirement.getText()

--- a/walk-in-interview/src/test/webapp/update-job/script_test.js
+++ b/walk-in-interview/src/test/webapp/update-job/script_test.js
@@ -444,6 +444,12 @@ describe('Update Job Tests', function() {
       // Since all fields should be pre-filled with existing job post,
       // there is no need to add valid inputs to all fields again.
 
+      it('no error message for all valid inputs', () => {
+        return clickUpdate(driver)
+            .then(() => driver.findElement(By.id('error-message')).getText())
+            .then((text) => assert.equal(text, ''));
+      });
+
       it('no job title', () => {
         /**
          * The job title must be cleared here to test it.
@@ -453,20 +459,6 @@ describe('Update Job Tests', function() {
             .then(() => driver.findElement(By.id('error-message')).getText())
             .then((text) => assert.equal(text,
                 'There is an error in the following field: Job Title'));
-      });
-
-      it('should not be false positive', () => {
-        /**
-         * The job title must be cleared here to test it.
-         * This test is making sure that the test is actually working
-         * properly and not just passing for any string.
-         * Note the use of assert.notEqual().
-         */
-        return driver.findElement(By.id('title')).clear()
-            .then(() => clickUpdate(driver))
-            .then(() => driver.findElement(By.id('error-message')).getText())
-            .then((text) => assert.notEqual(text,
-                'There is an error in the following field: '));
       });
 
       it('incorrect job address format', () => {


### PR DESCRIPTION
Fixed #65 

* Add a requirement filter so that an applicant without driving license will not see the job that requires a driving license
* Change the requirement schema for job post from list to `requirementTag: true/false`
    * Limitation: Assumes that the requirement list will not extend. If there needs to be more requirements, data migration is needed to update all the existing job posts with new requirement fields. E.g. there is a new requirement naming “HEIGHT”, then all existing job post `requirements` field need to update and add “HEIGHT”: false

* Write tests for `fetchAllEligibleJobs`